### PR TITLE
Make visibility timeout optional

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+### Libraries affected
+
+`messaging`
+
+### Description
+
+Localstack doesn't like specifying a visibility timeout so make it optional.


### PR DESCRIPTION
Localstack doesn't like specifying a visibility timeout so make it optional.