### PR TITLE
Add tag support for Azure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 ### Libraries affected
 
@@ -6,19 +6,22 @@ RELEASE_TYPE: major
 
 ### Description
 
-`RetryableGet` has been replaced in favour of `RetryableReadable`. 
-
-A new trait `Updatable` has been made available and is used in `Tags`.
+Adds Azure support for `Tags` in the shape of `AzureBlobMetadata`.
 
 ```scala
-trait Updatable[Ident, T] {
-  type UpdateEither = Either[UpdateError, Identified[Ident, T]]
-  type UpdateFunction = T => Either[UpdateFunctionError, T]
+implicit val azureClient: BlobServiceClient =
+  new BlobServiceClientBuilder()
+    .connectionString("UseDevelopmentStorage=true;")
+    .buildClient()
 
-  def update(id: Ident)(updateFunction: UpdateFunction): UpdateEither
+val azureBlobMetadata = new AzureBlobMetadata()
+
+// Get tags
+val objectLocation = ObjectLocation("mycontainer","myobject.txt")
+val getResult: Either[ReadError, Identified[Ident, T]]  = azureBlobMetadata.get(objectLocation)
+
+val newTags = Map("owner" -> "jill")
+val updateResult: Either[UpdateError, Identified[Ident, T]] = azureBlobMetadata.update(objectLocation) { oldTags =>
+    oldTags ++ newTags 
 }
 ```
-
-`Tags` now meets the interfaces of  to `RetryableReadable` and `Updatable`.
-
-Consumers will need to update code where `update` and `get` have been used on `S3Tags`.

--- a/new.RELEASE.md
+++ b/new.RELEASE.md
@@ -1,0 +1,27 @@
+RELEASE_TYPE: minor
+
+### Libraries affected
+
+`storage`
+
+### Description
+
+Adds Azure support for `Tags` in the shape of `AzureBlobMetadata`.
+
+```scala
+implicit val azureClient: BlobServiceClient =
+  new BlobServiceClientBuilder()
+    .connectionString("UseDevelopmentStorage=true;")
+    .buildClient()
+
+val azureBlobMetadata = new AzureBlobMetadata()
+
+// Get tags
+val objectLocation = ObjectLocation("mycontainer","myobject.txt")
+val getResult: Either[ReadError, Identified[Ident, T]]  = azureBlobMetadata.get(objectLocation)
+
+val newTags = Map("owner" -> "jill")
+val updateResult: Either[UpdateError, Identified[Ident, T]] = azureBlobMetadata.update(objectLocation) { oldTags =>
+    oldTags ++ newTags 
+}
+```

--- a/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureStorageErrors.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureStorageErrors.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.storage.azure
+
+import com.azure.storage.blob.models.BlobStorageException
+import uk.ac.wellcome.storage.{DoesNotExistError, ReadError, StoreReadError}
+
+object AzureStorageErrors {
+  val readErrors: PartialFunction[Throwable, ReadError] = {
+    case exc: BlobStorageException if exc.getStatusCode == 404 =>
+      DoesNotExistError(exc)
+    case exc =>
+      StoreReadError(exc)
+  }
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/Store.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/Store.scala
@@ -15,3 +15,10 @@ trait Writable[Ident, T] {
 
   def put(id: Ident)(t: T): WriteEither
 }
+
+trait Updatable[Ident, T] {
+  type UpdateEither = Either[UpdateError, Identified[Ident, T]]
+  type UpdateFunction = T => Either[UpdateFunctionError, T]
+
+  def update(id: Ident)(updateFunction: UpdateFunction): UpdateEither
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/azure/AzureStreamReadable.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/azure/AzureStreamReadable.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.storage.store.azure
 
 import com.azure.storage.blob.BlobServiceClient
-import com.azure.storage.blob.models.BlobStorageException
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.azure.AzureStorageErrors
 import uk.ac.wellcome.storage.store.RetryableReadable

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/azure/AzureStreamReadable.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/azure/AzureStreamReadable.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.storage.store.azure
 import com.azure.storage.blob.BlobServiceClient
 import com.azure.storage.blob.models.BlobStorageException
 import uk.ac.wellcome.storage._
+import uk.ac.wellcome.storage.azure.AzureStorageErrors
 import uk.ac.wellcome.storage.store.RetryableReadable
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
@@ -23,11 +24,5 @@ trait AzureStreamReadable extends RetryableReadable[InputStreamWithLength] {
   }
 
   def buildGetError(throwable: Throwable): ReadError =
-    throwable match {
-      case exc: BlobStorageException if exc.getStatusCode == 404 =>
-        DoesNotExistError(exc)
-      case _ =>
-        warn(s"Unrecognised error inside AzureReadable.get: $throwable")
-        StoreReadError(throwable)
-    }
+    AzureStorageErrors.readErrors(throwable)
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -2,14 +2,7 @@ package uk.ac.wellcome.storage.tags
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.store.Readable
-
-trait Updatable[Ident, T] {
-  type UpdateEither = Either[UpdateError, Identified[Ident, T]]
-  type UpdateFunction = T => Either[UpdateFunctionError, T]
-
-  def update(id: Ident)(updateFunction: UpdateFunction): UpdateEither
-}
+import uk.ac.wellcome.storage.store.{Readable, Updatable}
 
 trait Tags[Ident]
     extends Readable[Ident, Map[String, String]]

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -36,7 +36,7 @@ trait Tags[Ident]
         debug(s"Tags on $id: tags have changed, so writing new tags")
         writeTags(id = id, tags = newTags) match {
           case Right(value) => Right(Identified(id, value))
-          case Left(err)    => {
+          case Left(err) => {
             warn(s"Error when trying to write tags to $id: $err")
             Left(UpdateWriteError(err))
           }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -37,7 +37,7 @@ trait Tags[Ident]
         writeTags(id = id, tags = newTags) match {
           case Right(value) => Right(Identified(id, value))
           case Left(err) => {
-            warn(s"Error when trying to write tags to $id: $err")
+            warn(s"Tags on $id: error when trying to write: $err")
             Left(UpdateWriteError(err))
           }
         }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -36,7 +36,10 @@ trait Tags[Ident]
         debug(s"Tags on $id: tags have changed, so writing new tags")
         writeTags(id = id, tags = newTags) match {
           case Right(value) => Right(Identified(id, value))
-          case Left(err)    => Left(UpdateWriteError(err))
+          case Left(err)    => {
+            warn(s"Error when trying to write tags to $id: $err")
+            Left(UpdateWriteError(err))
+          }
         }
       }
     } yield result

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadata.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadata.scala
@@ -2,18 +2,26 @@ package uk.ac.wellcome.storage.tags.azure
 
 import com.azure.storage.blob.BlobServiceClient
 import uk.ac.wellcome.storage.azure.AzureStorageErrors
-import uk.ac.wellcome.storage.{ObjectLocation, ReadError, StoreWriteError, WriteError}
+import uk.ac.wellcome.storage.{
+  ObjectLocation,
+  ReadError,
+  StoreWriteError,
+  WriteError
+}
 import uk.ac.wellcome.storage.store.RetryableReadable
 import uk.ac.wellcome.storage.tags.Tags
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-class AzureBlobMetadata(val maxRetries: Int = 2)(implicit blobClient: BlobServiceClient)
-  extends Tags[ObjectLocation]
+class AzureBlobMetadata(val maxRetries: Int = 2)(
+  implicit blobClient: BlobServiceClient)
+    extends Tags[ObjectLocation]
     with RetryableReadable[Map[String, String]] {
 
-  override protected def writeTags(id: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+  override protected def writeTags(
+    id: ObjectLocation,
+    tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
     Try {
       val individualBlobClient =
         blobClient
@@ -22,24 +30,21 @@ class AzureBlobMetadata(val maxRetries: Int = 2)(implicit blobClient: BlobServic
 
       individualBlobClient.setMetadata(tags.asJava)
     } match {
-      case Success(_) => Right(tags)
+      case Success(_)   => Right(tags)
       case Failure(err) => Left(StoreWriteError(err))
     }
   }
 
-  override def retryableGetFunction(location: ObjectLocation): Map[String, String] = {
-      val individualBlobClient =
-        blobClient
-          .getBlobContainerClient(location.namespace)
-          .getBlobClient(location.path)
+  override def retryableGetFunction(
+    location: ObjectLocation): Map[String, String] = {
+    val individualBlobClient =
+      blobClient
+        .getBlobContainerClient(location.namespace)
+        .getBlobClient(location.path)
 
-    individualBlobClient
-      .getProperties
-      .getMetadata
-      .asScala.toMap
+    individualBlobClient.getProperties.getMetadata.asScala.toMap
   }
 
   override def buildGetError(throwable: Throwable): ReadError =
     AzureStorageErrors.readErrors(throwable)
 }
-

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadata.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadata.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.storage.tags.azure
+
+import com.azure.storage.blob.BlobServiceClient
+import uk.ac.wellcome.storage.azure.AzureStorageErrors
+import uk.ac.wellcome.storage.{ObjectLocation, ReadError, StoreWriteError, WriteError}
+import uk.ac.wellcome.storage.store.RetryableReadable
+import uk.ac.wellcome.storage.tags.Tags
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+class AzureBlobMetadata(val maxRetries: Int = 2)(implicit blobClient: BlobServiceClient)
+  extends Tags[ObjectLocation]
+    with RetryableReadable[Map[String, String]] {
+
+  override protected def writeTags(id: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+    Try {
+      val individualBlobClient =
+        blobClient
+          .getBlobContainerClient(id.namespace)
+          .getBlobClient(id.path)
+
+      individualBlobClient.setMetadata(tags.asJava)
+    } match {
+      case Success(_) => Right(tags)
+      case Failure(err) => Left(StoreWriteError(err))
+    }
+  }
+
+  override def retryableGetFunction(location: ObjectLocation): Map[String, String] = {
+      val individualBlobClient =
+        blobClient
+          .getBlobContainerClient(location.namespace)
+          .getBlobClient(location.path)
+
+    individualBlobClient
+      .getProperties
+      .getMetadata
+      .asScala.toMap
+  }
+
+  override def buildGetError(throwable: Throwable): ReadError =
+    AzureStorageErrors.readErrors(throwable)
+}
+

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/AzureFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/AzureFixtures.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.storage.fixtures
 import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import uk.ac.wellcome.fixtures.{Fixture, fixture}
+import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.RandomThings
 
 object AzureFixtures {
@@ -34,6 +35,14 @@ trait AzureFixtures extends RandomThings with Eventually with IntegrationPatienc
    */
   def createContainerName: String =
     randomAlphanumeric.toLowerCase
+
+  def createObjectLocationWith(
+                                container: Container
+                              ): ObjectLocation =
+    ObjectLocation(
+      namespace = container.name,
+      path = randomAlphanumeric
+    )
 
   def withAzureContainer[R]: Fixture[Container, R] =
     fixture[Container, R](

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.storage.tags.azure
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.AzureFixtures
+import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
+import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
+import scala.collection.JavaConverters._
+
+
+class AzureBlobMetadataTest
+  extends AnyFunSpec
+    with Matchers
+    with TagsTestCases[ObjectLocation, Container]
+    with AzureFixtures {
+
+  def putObject(location: ObjectLocation, metadata: Map[String, String] = Map.empty) = {
+    val streamLength = 256
+    val allowOverwrites = true
+    val inputStream = randomInputStream(length = streamLength)
+
+    val individualBlobClient =
+      azureClient
+        .getBlobContainerClient(location.namespace)
+        .getBlobClient(location.path)
+
+    individualBlobClient.upload(
+      inputStream,
+      streamLength,
+      allowOverwrites,
+    )
+
+    individualBlobClient
+      .setMetadata(metadata.asJava)
+  }
+
+  // TODO: TagsTestCases needs to handle Azure metadata
+  override def withTags[R](initialTags: Map[ObjectLocation, Map[String, String]])(testWith: TestWith[Tags[ObjectLocation], R]): R = {
+    initialTags
+      .foreach { case (location, tags) =>
+        putObject(
+          location = location,
+          metadata = tags
+        )
+      }
+
+  }
+
+  override def createIdent(context: Container): ObjectLocation = ???
+
+  override def withContext[R](testWith: TestWith[Container, R]): R = ???
+
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
@@ -34,9 +34,10 @@ class AzureBlobMetadataTest
 
     individualBlobClient
       .setMetadata(metadata.asJava)
+
+
   }
 
-  // TODO: TagsTestCases needs to handle Azure metadata
   override def withTags[R](initialTags: Map[ObjectLocation, Map[String, String]])(testWith: TestWith[Tags[ObjectLocation], R]): R = {
     initialTags
       .foreach { case (location, tags) =>
@@ -46,10 +47,15 @@ class AzureBlobMetadataTest
         )
       }
 
+    testWith(new AzureBlobMetadata())
   }
 
-  override def createIdent(context: Container): ObjectLocation = ???
+  override def createIdent(context: Container): ObjectLocation =
+    createObjectLocationWith(context)
 
-  override def withContext[R](testWith: TestWith[Container, R]): R = ???
+  override def withContext[R](testWith: TestWith[Container, R]): R =
+    withAzureContainer { container =>
+      testWith(container)
+    }
 
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
@@ -65,7 +65,7 @@ class AzureBlobMetadataTest
       testWith(container)
     }
 
-  it("if the tags are larger than 8KB in total") {
+  it("throws an error if the tags are larger than 8KB in total") {
     withAzureContainer { container =>
       val location = createObjectLocationWith(container)
       putObject(location)


### PR DESCRIPTION
Adds Azure support for `Tags` in the shape of `AzureBlobMetadata`.

```scala
implicit val azureClient: BlobServiceClient =
  new BlobServiceClientBuilder()
    .connectionString("UseDevelopmentStorage=true;")
    .buildClient()

val azureBlobMetadata = new AzureBlobMetadata()

// Get tags
val objectLocation = ObjectLocation("mycontainer","myobject.txt")
val getResult: Either[ReadError, Identified[Ident, T]]  = azureBlobMetadata.get(objectLocation)

val newTags = Map("owner" -> "jill")
val updateResult: Either[UpdateError, Identified[Ident, T]] = azureBlobMetadata.update(objectLocation) { oldTags =>
    oldTags ++ newTags 
}
```

For https://github.com/wellcomecollection/platform/issues/4397