### PR TITLE
PrefixTransferBuilder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds a builder for PrefixTransfer

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,26 @@
 RELEASE_TYPE: minor
 
+### Libraries affected
+
+`storage_typesafe`
+
 Adds a builder for PrefixTransfer
+
+With config:
+
+```hocon
+source.cloudProvider = "aws"
+destination {
+  cloudProvider = "azure"
+  azure.blobStore.connectionString = "UseDevelopmentStorage=true;"
+}
+```
+
+In code:
+
+```scala
+import uk.ac.wellcome.storage.typesafe.PrefixTransferBuilder
+
+val prefixTransfer = PrefixTransferBuilder.build(config)
+assert(prefixTransfer.isInstanceOf[S3toAzurePrefixTransfer])
+```

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilder.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.storage.typesafe
+
+import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
+import com.typesafe.config.Config
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+object AzureBlobServiceClientBuilder {
+  def build(config: Config): BlobServiceClient = {
+    val connectionString = config
+      .requireString("azure.blobStore.connectionString")
+
+      new BlobServiceClientBuilder()
+        .connectionString(connectionString)
+        .buildClient()
+  }
+}

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilder.scala
@@ -9,8 +9,8 @@ object AzureBlobServiceClientBuilder {
     val connectionString = config
       .requireString("azure.blobStore.connectionString")
 
-      new BlobServiceClientBuilder()
-        .connectionString(connectionString)
-        .buildClient()
+    new BlobServiceClientBuilder()
+      .connectionString(connectionString)
+      .buildClient()
   }
 }

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.storage.typesafe
+
+import com.typesafe.config.Config
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+object PrefixTransferBuilder {
+  import CloudProvider._
+
+  //  ## Expects HOCON config like:
+  //  {
+  //    cloudProvider = "aws"
+  //    aws.s3.region = "eu-west-1"
+  //  }
+  //  ## OR
+  //  {
+  //    cloudProvider = "azure"
+  //    azure.blobStore.connectionString = "UseDevelopmentStorage=true;"
+  //  }
+  //
+
+  def build(config: Config) = {
+    val cloudProvider = config
+      .getStringOption("cloudProvider")
+      .flatMap(CloudProvider.create)
+      .getOrElse(AWS)
+
+    
+  }
+
+}

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
@@ -1,30 +1,73 @@
 package uk.ac.wellcome.storage.typesafe
 
+import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
+import uk.ac.wellcome.storage.listing.s3.{S3ObjectLocationListing, S3ObjectSummaryListing}
+import uk.ac.wellcome.storage.store.s3.S3StreamReadable
+import uk.ac.wellcome.storage.transfer.azure.{S3toAzurePrefixTransfer, S3toAzureTransfer}
+import uk.ac.wellcome.storage.transfer.s3.{S3PrefixTransfer, S3Transfer}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object PrefixTransferBuilder {
   import CloudProvider._
 
   //  ## Expects HOCON config like:
-  //  {
-  //    cloudProvider = "aws"
-  //    aws.s3.region = "eu-west-1"
-  //  }
+  //  source.cloudProvider = "aws"
+  //  destination.cloudProvider = "aws"
+  //
   //  ## OR
-  //  {
+  //  source.cloudProvider = "aws"
+  //  destination {
   //    cloudProvider = "azure"
   //    azure.blobStore.connectionString = "UseDevelopmentStorage=true;"
   //  }
   //
 
   def build(config: Config) = {
-    val cloudProvider = config
-      .getStringOption("cloudProvider")
+
+    class S3Reader(val maxRetries: Int = 3)(implicit val s3Client: AmazonS3)
+        extends S3StreamReadable
+
+    val srcCloudProvider = config
+      .getStringOption("source.cloudProvider")
       .flatMap(CloudProvider.create)
       .getOrElse(AWS)
 
-    
-  }
+    val dstCloudProvider = config
+      .getStringOption("destination.cloudProvider")
+      .flatMap(CloudProvider.create)
+      .getOrElse(AWS)
 
+    (srcCloudProvider, dstCloudProvider) match {
+      case (AWS, AWS) => {
+        implicit val s3Client = S3Builder.buildS3Client(config)
+        implicit val summary = new S3ObjectSummaryListing()
+
+        implicit val transfer = new S3Transfer()
+        implicit val listing = new S3ObjectLocationListing()
+
+        new S3PrefixTransfer()
+      }
+      case (AWS, Azure) => {
+        val srcConfig = config.getConfig("source")
+        val dstConfig = config.getConfig("destination")
+
+        implicit val s3Client = S3Builder.buildS3Client(srcConfig)
+        implicit val azureClient = AzureBlobServiceClientBuilder.build(dstConfig)
+
+        implicit val s3Reader = new S3Reader()
+        implicit val s3toAzureTransfer = new S3toAzureTransfer()
+
+        implicit val summary = new S3ObjectSummaryListing()
+        implicit val listing = new S3ObjectLocationListing()
+
+        new S3toAzurePrefixTransfer()
+      }
+
+      case _ =>
+        throw new Exception(
+          s"Invalid (source, destination) combination: ($srcCloudProvider, $dstCloudProvider)"
+        )
+    }
+  }
 }

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilder.scala
@@ -2,9 +2,15 @@ package uk.ac.wellcome.storage.typesafe
 
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
-import uk.ac.wellcome.storage.listing.s3.{S3ObjectLocationListing, S3ObjectSummaryListing}
+import uk.ac.wellcome.storage.listing.s3.{
+  S3ObjectLocationListing,
+  S3ObjectSummaryListing
+}
 import uk.ac.wellcome.storage.store.s3.S3StreamReadable
-import uk.ac.wellcome.storage.transfer.azure.{S3toAzurePrefixTransfer, S3toAzureTransfer}
+import uk.ac.wellcome.storage.transfer.azure.{
+  S3toAzurePrefixTransfer,
+  S3toAzureTransfer
+}
 import uk.ac.wellcome.storage.transfer.s3.{S3PrefixTransfer, S3Transfer}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
@@ -53,7 +59,8 @@ object PrefixTransferBuilder {
         val dstConfig = config.getConfig("destination")
 
         implicit val s3Client = S3Builder.buildS3Client(srcConfig)
-        implicit val azureClient = AzureBlobServiceClientBuilder.build(dstConfig)
+        implicit val azureClient =
+          AzureBlobServiceClientBuilder.build(dstConfig)
 
         implicit val s3Reader = new S3Reader()
         implicit val s3toAzureTransfer = new S3toAzureTransfer()

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/TagsBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/TagsBuilder.scala
@@ -24,7 +24,7 @@ object TagsBuilder {
   //  }
   //
 
-  def buildClient(config: Config)
+  def build(config: Config)
     : Tags[ObjectLocation] with RetryableReadable[Map[String, String]] = {
 
     val cloudProvider = config

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/TagsBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/TagsBuilder.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.storage.typesafe
 
-import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
 import com.typesafe.config.Config
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.RetryableReadable
@@ -38,14 +37,7 @@ object TagsBuilder {
         new S3Tags()(s3Client)
       }
       case Azure => {
-        val connectionString = config
-          .requireString("azure.blobStore.connectionString")
-
-        val azureClient: BlobServiceClient =
-          new BlobServiceClientBuilder()
-            .connectionString(connectionString)
-            .buildClient()
-
+        val azureClient = AzureBlobServiceClientBuilder.build(config)
         new AzureBlobMetadata()(azureClient)
       }
     }

--- a/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilderTest.scala
+++ b/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/AzureBlobServiceClientBuilderTest.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.storage.typesafe
+
+import com.azure.storage.blob.BlobServiceClient
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class AzureBlobServiceClientBuilderTest extends AnyFunSpec with Matchers {
+  describe("with config") {
+    val configString =
+      """
+        |azure {
+        |   blobStore.connectionString = "UseDevelopmentStorage=true;"
+        |}
+        |""".stripMargin
+
+    it("creates AzureBlobServiceClient") {
+      val config = ConfigFactory.parseString(configString)
+
+      AzureBlobServiceClientBuilder.build(config) shouldBe a[BlobServiceClient]
+    }
+  }
+}

--- a/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilderTest.scala
+++ b/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/PrefixTransferBuilderTest.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.storage.typesafe
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.storage.transfer.azure.S3toAzurePrefixTransfer
+
+class PrefixTransferBuilderTest extends AnyFunSpec with Matchers {
+  describe("with config for: source AWS, destination Azure") {
+    val configString =
+      """
+        |source.cloudProvider = "aws"
+        |destination {
+        |   cloudProvider = "azure"
+        |   azure.blobStore.connectionString = "UseDevelopmentStorage=true;"
+        |}
+        |""".stripMargin
+
+    it("creates a S3toAzurePrefixTransfer") {
+      val config = ConfigFactory.parseString(configString)
+
+      val prefixTransfer = PrefixTransferBuilder.build(config)
+
+      prefixTransfer shouldBe a[S3toAzurePrefixTransfer]
+    }
+  }
+}

--- a/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/TagsBuilderTest.scala
+++ b/storage_typesafe/src/test/scala/uk/ac/wellcome/storage/typesafe/TagsBuilderTest.scala
@@ -21,7 +21,7 @@ class TagsBuilderTest extends AnyFunSpec with Matchers {
     it("creates S3Tags") {
       val awsConfig = ConfigFactory.parseString(awsConfigString)
       val targetConfig = awsConfig.getConfig("somepath")
-      val tags = TagsBuilder.buildClient(targetConfig)
+      val tags = TagsBuilder.build(targetConfig)
 
       tags shouldBe a[S3Tags]
     }
@@ -40,7 +40,7 @@ class TagsBuilderTest extends AnyFunSpec with Matchers {
     it("creates AzureBlobMetadata") {
       val azureConfig = ConfigFactory.parseString(azureConfigString)
       val targetConfig = azureConfig.getConfig("somepath")
-      val tags = TagsBuilder.buildClient(targetConfig)
+      val tags = TagsBuilder.build(targetConfig)
 
       tags shouldBe a[AzureBlobMetadata]
     }
@@ -58,7 +58,7 @@ class TagsBuilderTest extends AnyFunSpec with Matchers {
     it("creates S3Tags") {
       val awsConfig = ConfigFactory.parseString(awsConfigString)
       val targetConfig = awsConfig.getConfig("somepath")
-      val tags = TagsBuilder.buildClient(targetConfig)
+      val tags = TagsBuilder.build(targetConfig)
 
       tags shouldBe a[S3Tags]
     }


### PR DESCRIPTION
Adds a PrefixTransferBuilder.

### Libraries affected

`storage_typesafe`

Adds a builder for PrefixTransfer

With config:

```hocon
source.cloudProvider = "aws"
destination {
  cloudProvider = "azure"
  azure.blobStore.connectionString = "UseDevelopmentStorage=true;"
}
```

In code:

```scala
import uk.ac.wellcome.storage.typesafe.PrefixTransferBuilder
val prefixTransfer = PrefixTransferBuilder.build(config)
assert(prefixTransfer.isInstanceOf[S3toAzurePrefixTransfer])
```