### PR TITLE
Store Instants in Dynamo as timestamps in seconds

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+### Libraries affected
+
+`storage`
+
+### Description
+
+Store Instants in Dynamo as *seconds* since the epoch, not *milliseconds*.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,9 +29,9 @@ object Dependencies {
 
   val circeDependencies = Seq(
     "io.circe" %% "circe-core" % versions.circe,
-    "io.circe" %% "circe-generic"% versions.circe,
-    "io.circe" %% "circe-generic-extras"% versions.circe,
-    "io.circe" %% "circe-parser"% versions.circe
+    "io.circe" %% "circe-generic" % versions.circe,
+    "io.circe" %% "circe-generic-extras" % versions.circe,
+    "io.circe" %% "circe-parser" % versions.circe
   )
 
   val testDependencies = Seq(
@@ -68,8 +68,7 @@ object Dependencies {
   )
 
   val scanamoDependencies = Seq(
-    "org.scanamo" %% "scanamo" % versions.scanamo,
-    "org.scanamo" %% "scanamo-time" % versions.scanamo
+    "org.scanamo" %% "scanamo" % versions.scanamo
   )
 
   val openTracingDependencies = Seq(
@@ -77,7 +76,7 @@ object Dependencies {
     "io.opentracing" % "opentracing-mock" % "0.33.0" % Test
   )
 
-  val elasticApmBridgeDependencies = Seq (
+  val elasticApmBridgeDependencies = Seq(
     "co.elastic.apm" % "apm-opentracing" % versions.elasticApm,
     "co.elastic.apm" % "apm-agent-attach" % versions.elasticApm
   )
@@ -91,9 +90,9 @@ object Dependencies {
     "software.amazon.awssdk" % "sns" % versions.aws2,
     "software.amazon.awssdk" % "sqs" % versions.aws2,
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakka
-      // This needs to be excluded bacuse it conflicts with aws http client "netty-nio-client"
-      // and it also causes weird leaks between tests
-      exclude("com.github.matsluni", "aws-spi-akka-http_2.12"),
+    // This needs to be excluded bacuse it conflicts with aws http client "netty-nio-client"
+    // and it also causes weird leaks between tests
+      exclude ("com.github.matsluni", "aws-spi-akka-http_2.12"),
     "io.circe" %% "circe-yaml" % versions.circe
   ) ++
     openTracingDependencies ++
@@ -102,8 +101,8 @@ object Dependencies {
 
   val jsonDependencies =
     circeDependencies ++
-    sl4jDependencies ++
-    testDependencies
+      sl4jDependencies ++
+      testDependencies
 
   val fixturesDependencies =
     sl4jDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,7 +90,7 @@ object Dependencies {
     "software.amazon.awssdk" % "sns" % versions.aws2,
     "software.amazon.awssdk" % "sqs" % versions.aws2,
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakka
-    // This needs to be excluded bacuse it conflicts with aws http client "netty-nio-client"
+    // This needs to be excluded because it conflicts with aws http client "netty-nio-client"
     // and it also causes weird leaks between tests
       exclude ("com.github.matsluni", "aws-spi-akka-http_2.12"),
     "io.circe" %% "circe-yaml" % versions.circe

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,8 @@ object Dependencies {
   )
 
   val scanamoDependencies = Seq(
-    "org.scanamo" %% "scanamo" % versions.scanamo
+    "org.scanamo" %% "scanamo" % versions.scanamo,
+    "org.scanamo" %% "scanamo-time" % versions.scanamo
   )
 
   val openTracingDependencies = Seq(

--- a/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoTimeFormat.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoTimeFormat.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.storage.dynamo
+
+import java.time.Instant
+
+import org.scanamo.DynamoFormat
+
+object DynamoTimeFormat {
+  implicit val instantAsLongSecondsFormat: DynamoFormat[Instant] =
+    DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](x =>
+      Instant.ofEpochSecond(x))(x => x.getEpochSecond)
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoTimeFormat.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoTimeFormat.scala
@@ -5,6 +5,13 @@ import java.time.Instant
 import org.scanamo.DynamoFormat
 
 object DynamoTimeFormat {
+
+  // We use this rather than scanamo.time.JavaTimeFormats._ because Dynamo's
+  // builtin item expiry feature requires the TTL value to be in seconds,
+  // rather than the library's milliseconds since the epoch.
+  //
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-before-you-start.html#time-to-live-ttl-before-you-start-formatting
+  // https://github.com/scanamo/scanamo/blob/v1.0.0-M10/java-time/src/main/scala/org/scanamo/time/JavaTimeFormats.scala#L20
   implicit val instantAsLongSecondsFormat: DynamoFormat[Instant] =
     DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](x =>
       Instant.ofEpochSecond(x))(x => x.getEpochSecond)

--- a/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
@@ -9,9 +9,9 @@ import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import grizzled.slf4j.Logging
 import org.scanamo.query.Condition
 import org.scanamo.syntax._
-import org.scanamo.time.JavaTimeFormats._
 import org.scanamo.{DynamoFormat, Table => ScanamoTable}
 import uk.ac.wellcome.storage.locking.{LockDao, LockFailure, UnlockFailure}
+import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try

--- a/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoFormatTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/dynamo/DynamoFormatTest.scala
@@ -15,7 +15,8 @@ import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import org.scanamo.auto._
 import org.scanamo.error.InvalidPropertiesError
 import org.scanamo.{Table => ScanamoTable}
-import org.scanamo.time.JavaTimeFormats._
+
+import DynamoTimeFormat._
 
 trait DynamoFormatTestCases[T]
     extends AnyFunSpec
@@ -64,12 +65,13 @@ trait DynamoFormatTestCases[T]
 
 class DynamoInstantFormatTest extends DynamoFormatTestCases[Instant] {
   def createT: Instant =
-    Instant.now()
-      .truncatedTo( ChronoUnit.MILLIS )
+    Instant
+      .now()
+      .truncatedTo(ChronoUnit.SECONDS)
 
   def createBadT: String = "not a valid datetime"
 
-  implicit val dynamoFormat: DynamoFormat[Instant] = instantAsLongFormat
+  implicit val dynamoFormat: DynamoFormat[Instant] = instantAsLongSecondsFormat
 }
 
 class DynamoURIFormatTest extends DynamoFormatTestCases[URI] {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
@@ -8,12 +8,12 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
 import org.scalatest.Assertion
 import org.scanamo.auto._
-import org.scanamo.time.JavaTimeFormats._
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.locking.{LockDao, LockDaoFixtures}
+import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoTest.scala
@@ -9,9 +9,13 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatestplus.mockito.MockitoSugar
 import org.scanamo.auto._
-import org.scanamo.time.JavaTimeFormats._
+import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
-import uk.ac.wellcome.storage.locking.{LockDaoTestCases, LockFailure, UnlockFailure}
+import uk.ac.wellcome.storage.locking.{
+  LockDaoTestCases,
+  LockFailure,
+  UnlockFailure
+}
 
 class DynamoLockDaoTest
     extends LockDaoTestCases[String, UUID, Table]

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockingServiceTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockingServiceTest.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import org.scalatest.EitherValues
 import org.scanamo.auto._
-import org.scanamo.time.JavaTimeFormats._
+import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.locking.LockingServiceTestCases
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/azure/AzureBlobMetadataTest.scala
@@ -14,14 +14,14 @@ import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
 
 import scala.collection.JavaConverters._
 
-
 class AzureBlobMetadataTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with TagsTestCases[ObjectLocation, Container]
     with AzureFixtures {
 
-  def putObject(location: ObjectLocation, metadata: Map[String, String] = Map.empty) = {
+  def putObject(location: ObjectLocation,
+                metadata: Map[String, String] = Map.empty) = {
     val streamLength = 256
     val allowOverwrites = true
     val inputStream = randomInputStream(length = streamLength)
@@ -40,16 +40,18 @@ class AzureBlobMetadataTest
     individualBlobClient
       .setMetadata(metadata.asJava)
 
-
   }
 
-  override def withTags[R](initialTags: Map[ObjectLocation, Map[String, String]])(testWith: TestWith[Tags[ObjectLocation], R]): R = {
+  override def withTags[R](
+    initialTags: Map[ObjectLocation, Map[String, String]])(
+    testWith: TestWith[Tags[ObjectLocation], R]): R = {
     initialTags
-      .foreach { case (location, tags) =>
-        putObject(
-          location = location,
-          metadata = tags
-        )
+      .foreach {
+        case (location, tags) =>
+          putObject(
+            location = location,
+            metadata = tags
+          )
       }
 
     testWith(new AzureBlobMetadata())
@@ -80,13 +82,14 @@ class AzureBlobMetadataTest
           }
 
       assertIsBlobStoreException(result) {
-        // Azurite does not seem to offer a useful status code
-        _ should startWith("Status code 400")
+        _ should startWith("Status code 431")
       }
     }
   }
 
-  private def assertIsBlobStoreException(result: azureBlobMetadata.UpdateEither)(assert: String => Assertion): Assertion = {
+  private def assertIsBlobStoreException(
+    result: azureBlobMetadata.UpdateEither)(
+    assert: String => Assertion): Assertion = {
     val err = result.left.value
 
     err shouldBe a[UpdateWriteError]

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
@@ -3,6 +3,8 @@ package uk.ac.wellcome.storage.typesafe
 import java.time.Duration
 
 import com.typesafe.config.Config
+import org.scanamo.auto._
+import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDao,
   DynamoLockDaoConfig,

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
@@ -3,8 +3,6 @@ package uk.ac.wellcome.storage.typesafe
 import java.time.Duration
 
 import com.typesafe.config.Config
-import org.scanamo.auto._
-import org.scanamo.time.JavaTimeFormats._
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDao,
   DynamoLockDaoConfig,


### PR DESCRIPTION
Does what it says on the tin so that Dynamo can remove expired rows