### PR TITLE
Add the base Location classes plus compatibility shims

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This release introduces four new classes in the **storage** library:
+
+-   `S3ObjectLocation`
+-   `S3ObjectLocationPrefix`
+-   `AzureBlobLocation`
+-   `AzureBlobLocationPrefix`
+
+which extend new traits `Location` and `Prefix`, respectively.
+
+These will eventually replace the existing `ObjectLocation` class, but `S3ObjectLocation` should be a drop-in replacement in all existing code.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/Location.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/Location.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.storage
+
+trait Location

--- a/storage/src/main/scala/uk/ac/wellcome/storage/Prefix.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/Prefix.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.storage
+
+trait Prefix[OfLocation <: Location]

--- a/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
@@ -103,7 +103,6 @@ case class NoMaximaValueError(e: Throwable = new Error())
     extends MaximaError
     with StorageError
 
-case class ListingFailure[SrcLocation](
-  source: SrcLocation,
-  e: Throwable = new Error())
+case class ListingFailure[SrcLocation](source: SrcLocation,
+                                       e: Throwable = new Error())
     extends ReadError

--- a/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
@@ -103,6 +103,7 @@ case class NoMaximaValueError(e: Throwable = new Error())
     extends MaximaError
     with StorageError
 
-case class ListingFailure[Location](source: Location,
-                                    e: Throwable = new Error())
+case class ListingFailure[SrcLocation](
+  source: SrcLocation,
+  e: Throwable = new Error())
     extends ReadError

--- a/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureBlobLocation.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureBlobLocation.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.storage.azure
+
+import uk.ac.wellcome.storage.{Location, Prefix}
+
+case class AzureBlobLocation(
+  container: String,
+  name: String
+) extends Location {
+  override def toString: String =
+    s"azure://$container/$name"
+}
+
+case class AzureBlobLocationPrefix(
+  container: String,
+  namePrefix: String
+) extends Prefix[AzureBlobLocation] {
+  override def toString: String =
+    s"azure://$container/$namePrefix"
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ObjectLocation.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ObjectLocation.scala
@@ -27,7 +27,8 @@ case class S3ObjectLocationPrefix(
 //
 // These decoders allow you to read JSON that was encoded with the old code.
 trait S3Decodable {
-  def createDecoder[T](keyField: String)(constructor: (String, String) => T): Decoder[T] =
+  def createDecoder[T](keyField: String)(
+    constructor: (String, String) => T): Decoder[T] =
     (cursor: HCursor) => {
       val oldStyle: Either[DecodingFailure, T] =
         for {
@@ -63,11 +64,13 @@ trait S3Decodable {
         (oldStyle, newStyle) match {
           case (Success(location), _) => location
           case (_, Success(location)) => location
-          case (_, Failure(err)) => throw err
+          case (_, Failure(err))      => throw err
         }
       }
     )(
-      write = { t: T => encoder(t) }
+      write = { t: T =>
+        encoder(t)
+      }
     )
 }
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ObjectLocation.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3ObjectLocation.scala
@@ -1,0 +1,106 @@
+package uk.ac.wellcome.storage.s3
+
+import io.circe.{Decoder, DecodingFailure, HCursor}
+import org.scanamo.DynamoFormat
+import uk.ac.wellcome.storage.{Location, Prefix}
+
+import scala.util.{Failure, Success, Try}
+
+case class S3ObjectLocation(
+  bucket: String,
+  key: String
+) extends Location {
+  override def toString: String =
+    s"s3://$bucket/$key"
+}
+
+case class S3ObjectLocationPrefix(
+  bucket: String,
+  keyPrefix: String
+) extends Prefix[S3ObjectLocation] {
+  override def toString: String =
+    s"s3://$bucket/$keyPrefix"
+}
+
+// Note: the precursor to these classes was ObjectLocation, which used the
+// fields "namespace/path" rather than provider-specific terms.
+//
+// These decoders allow you to read JSON that was encoded with the old code.
+trait S3Decodable {
+  def createDecoder[T](keyField: String)(constructor: (String, String) => T): Decoder[T] =
+    (cursor: HCursor) => {
+      val oldStyle: Either[DecodingFailure, T] =
+        for {
+          bucket <- cursor.downField("namespace").as[String]
+          key <- cursor.downField("path").as[String]
+        } yield constructor(bucket, key)
+
+      val newStyle =
+        for {
+          bucket <- cursor.downField("bucket").as[String]
+          key <- cursor.downField(keyField).as[String]
+        } yield constructor(bucket, key)
+
+      (oldStyle, newStyle) match {
+        case (Right(location), _)       => Right(location)
+        case (_, Right(location))       => Right(location)
+        case (_, Left(decodingFailure)) => Left(decodingFailure)
+      }
+    }
+
+  case class OldLocation(namespace: String, path: String)
+
+  def createDynamoFormat[T](
+    decoder: (String, String) => T,
+    keyField: String,
+    encoder: T => Map[String, String]
+  ): DynamoFormat[T] =
+    DynamoFormat.coercedXmap[T, Map[String, String], Throwable](
+      read = { values: Map[String, String] =>
+        val oldStyle = Try { decoder(values("namespace"), values("path")) }
+        val newStyle = Try { decoder(values("bucket"), values(keyField)) }
+
+        (oldStyle, newStyle) match {
+          case (Success(location), _) => location
+          case (_, Success(location)) => location
+          case (_, Failure(err)) => throw err
+        }
+      }
+    )(
+      write = { t: T => encoder(t) }
+    )
+}
+
+case object S3ObjectLocation extends S3Decodable {
+  implicit val decoder: Decoder[S3ObjectLocation] =
+    createDecoder[S3ObjectLocation](keyField = "key") {
+      (bucket: String, key: String) =>
+        S3ObjectLocation(bucket = bucket, key = key)
+    }
+
+  implicit val format: DynamoFormat[S3ObjectLocation] =
+    createDynamoFormat[S3ObjectLocation](
+      decoder = (bucket: String, key: String) =>
+        S3ObjectLocation(bucket = bucket, key = key),
+      keyField = "key",
+      encoder = (location: S3ObjectLocation) =>
+        Map("bucket" -> location.bucket, "key" -> location.key)
+    )
+}
+
+case object S3ObjectLocationPrefix extends S3Decodable {
+  implicit val decoder: Decoder[S3ObjectLocationPrefix] =
+    createDecoder[S3ObjectLocationPrefix](keyField = "keyPrefix") {
+      (bucket: String, keyPrefix: String) =>
+        S3ObjectLocationPrefix(bucket = bucket, keyPrefix = keyPrefix)
+    }
+
+  implicit val format: DynamoFormat[S3ObjectLocationPrefix] =
+    createDynamoFormat[S3ObjectLocationPrefix](
+      decoder = (bucket: String, keyPrefix: String) =>
+        S3ObjectLocationPrefix(bucket = bucket, keyPrefix = keyPrefix),
+      keyField = "keyPrefix",
+      encoder = (location: S3ObjectLocationPrefix) =>
+        Map("bucket" -> location.bucket, "keyPrefix" -> location.keyPrefix)
+    )
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3Fixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3Fixtures.scala
@@ -12,7 +12,7 @@ import org.scalatest.{Assertion, EitherValues}
 import uk.ac.wellcome.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.generators.{ObjectLocationGenerators, S3ObjectLocationGenerators}
 import uk.ac.wellcome.storage.s3.{S3ClientFactory, S3Config}
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
@@ -36,7 +36,8 @@ trait S3Fixtures
     with IntegrationPatience
     with Matchers
     with EitherValues
-    with ObjectLocationGenerators {
+    with ObjectLocationGenerators
+    with S3ObjectLocationGenerators {
 
   import S3Fixtures._
 
@@ -105,14 +106,6 @@ trait S3Fixtures
     implicit decoder: Decoder[T]): T =
     fromJson[T](getContentFromS3(location)).get
 
-  def createBucketName: String =
-    // Bucket names
-    //  - start with a lowercase letter or number,
-    //  - do not contain uppercase characters or underscores,
-    //  - between 3 and 63 characters in length.
-    // [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]
-    randomAlphanumeric.toLowerCase
-
   def createInvalidBucketName: String =
     // Create a variety of invalid patterns, and choose one at random.
     Random
@@ -124,9 +117,6 @@ trait S3Fixtures
           Random.alphanumeric.take(100) mkString
         ))
       .head
-
-  def createBucket: Bucket =
-    Bucket(createBucketName)
 
   def createObjectLocationWith(
     bucket: Bucket

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.storage.generators
+
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+
+trait S3ObjectLocationGenerators extends RandomThings {
+  def createBucketName: String =
+    // Bucket names
+    //  - start with a lowercase letter or number,
+    //  - do not contain uppercase characters or underscores,
+    //  - between 3 and 63 characters in length.
+    // [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]
+    randomAlphanumeric.toLowerCase
+
+  def createBucket: Bucket = Bucket(createBucketName)
+
+  def createS3ObjectLocationWith(bucket: Bucket): S3ObjectLocation =
+    S3ObjectLocation(
+      bucket = bucket.name,
+      key = randomAlphanumeric
+    )
+
+  def createS3ObjectLocation: S3ObjectLocation = createS3ObjectLocationWith(bucket = createBucket)
+
+  def createS3ObjectLocationPrefixWith(bucket: Bucket): S3ObjectLocationPrefix =
+    S3ObjectLocationPrefix(
+      bucket = bucket.name,
+      keyPrefix = randomAlphanumeric
+    )
+
+  def createS3ObjectLocationPrefix: S3ObjectLocationPrefix =
+    createS3ObjectLocationPrefixWith(bucket = createBucket)
+
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
@@ -1,0 +1,137 @@
+package uk.ac.wellcome.storage.s3
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.auto._
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import org.scalatest.EitherValues
+import uk.ac.wellcome.storage.fixtures.DynamoFixtures
+
+class S3ObjectLocationTest
+  extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with DynamoFixtures
+    with S3ObjectLocationGenerators {
+
+  import S3ObjectLocation._
+  import S3ObjectLocationPrefix._
+
+  describe("S3ObjectLocation") {
+    describe("JSON") {
+      it("can serialise and deserialise to JSON") {
+        val location = createS3ObjectLocation
+
+        val jsonString = toJson(location).get
+
+        fromJson[S3ObjectLocation](jsonString).get shouldBe location
+      }
+
+      it("can serialise an old-style ObjectLocation from Json") {
+        val jsonString = """{"namespace": "my-bukkit", "path": "path/to/my/key.txt"}"""
+
+        val location = fromJson[S3ObjectLocation](jsonString).get
+
+        location shouldBe S3ObjectLocation(
+          bucket = "my-bukkit",
+          key = "path/to/my/key.txt"
+        )
+      }
+    }
+
+    describe("DynamoDB") {
+      case class IdentifiedLocation(
+        id: String, location: S3ObjectLocation
+      )
+
+      val item = IdentifiedLocation(
+        id = "cat", location = S3ObjectLocation(bucket = "my-bukkit", key = "cat.jpg")
+      )
+
+      it("can store a location in DynamoDB") {
+        withLocalDynamoDbTable { table =>
+          putTableItem(table = table, item = item)
+
+          getTableItem[IdentifiedLocation](id = item.id, table = table).get.right.value shouldBe item
+        }
+      }
+
+      it("can retrieve an old-style location from DynamoDB") {
+        case class OldLocation(namespace: String, path: String)
+        case class OldItem(id: String, location: OldLocation)
+
+        val oldItem = OldItem(
+          id = "cat",
+          location = OldLocation(namespace = "my-bukkit", path = "cat.jpg")
+        )
+
+        withLocalDynamoDbTable { table =>
+          putTableItem(table = table, item = oldItem)
+
+          getTableItem[IdentifiedLocation](id = item.id, table = table).get.right.value shouldBe item
+        }
+      }
+    }
+  }
+
+  describe("S3ObjectLocationPrefix") {
+    describe("JSON") {
+      it("can serialise and deserialise to JSON") {
+        val prefix = createS3ObjectLocationPrefix
+
+        val jsonString = toJson(prefix).get
+
+        fromJson[S3ObjectLocationPrefix](jsonString).get shouldBe prefix
+      }
+
+      it("can serialise an old-style ObjectLocationPrefix from Json") {
+        val jsonString = """{"namespace": "my-bukkit", "path": "path/to/my/directory"}"""
+
+        val prefix = fromJson[S3ObjectLocationPrefix](jsonString).get
+
+        prefix shouldBe S3ObjectLocationPrefix(
+          bucket = "my-bukkit",
+          keyPrefix = "path/to/my/directory"
+        )
+      }
+    }
+
+    describe("DynamoDB") {
+      case class IdentifiedLocation(
+        id: String, location: S3ObjectLocationPrefix
+      )
+
+      val item = IdentifiedLocation(
+        id = "cats", location = S3ObjectLocationPrefix(bucket = "my-bukkit", keyPrefix = "dir/of/cats")
+      )
+
+      it("can store a location in DynamoDB") {
+        withLocalDynamoDbTable { table =>
+          putTableItem(table = table, item = item)
+
+          getTableItem[IdentifiedLocation](id = item.id, table = table).get.right.value shouldBe item
+        }
+      }
+
+      it("can retrieve an old-style location from DynamoDB") {
+        case class OldPrefix(namespace: String, path: String)
+        case class OldItem(id: String, location: OldPrefix)
+
+        val oldItem = OldItem(
+          id = "cats",
+          location = OldPrefix(namespace = "my-bukkit", path = "dir/of/cats")
+        )
+
+        withLocalDynamoDbTable { table =>
+          putTableItem(table = table, item = oldItem)
+
+          getTableItem[IdentifiedLocation](id = item.id, table = table).get.right.value shouldBe item
+        }
+      }
+    }
+  }
+
+  override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table =
+    createTableWithHashKey(table)
+}


### PR DESCRIPTION
Starting to bring across bits of https://github.com/wellcomecollection/platform/issues/4596

This includes compatibility shims so you can read from an existing data store that uses ObjectLocation[Prefix] with S3ObjectLocation[Prefix], and it should transparently decode the old-style data for you.