### PR TITLE
Fix MemoryMessageSender dropping messages with concurrent writes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+`send` on `MemoryIndividualMessageSender` now updates its internal message list using `synchronized` to prevent dropping entries with concurrent writes.

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/memory/MemoryMessageSender.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/memory/MemoryMessageSender.scala
@@ -17,7 +17,9 @@ class MemoryIndividualMessageSender extends IndividualMessageSender[String] {
 
   override def send(body: String)(subject: String,
                                   destination: String): Try[Unit] = Try {
-    messages = messages :+ MemoryMessage(body, subject, destination)
+    this.synchronized {
+      messages = messages :+ MemoryMessage(body, subject, destination)
+    }
   }
 
   def getMessages[T]()(implicit decoder: Decoder[T]): Seq[T] =


### PR DESCRIPTION
`send` on `MemoryIndividualMessageSender` now updates its internal message list using `synchronized` to prevent dropping entries with concurrent writes.