### PR TITLE
Add some tests that we remove double slashes when joining paths

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Add some tests that we remove double slashes when joining paths.
+
+This isn't a change in behaviour, just a new test to avoid regressing this behaviour in future.

--- a/storage/src/test/scala/uk/ac/wellcome/storage/azure/AzureBlobLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/azure/AzureBlobLocationTest.scala
@@ -14,6 +14,13 @@ class AzureBlobLocationTest extends AnyFunSpec with Matchers {
       )
     }
 
+    it("removes double slashes when joining paths") {
+      loc.join("trailing-slash/", "cornish-rex.jpg") shouldBe AzureBlobLocation(
+        container = "my-azure-container",
+        name = "path/to/pictures/trailing-slash/cornish-rex.jpg"
+      )
+    }
+
     it("creates a prefix") {
       loc.asPrefix shouldBe AzureBlobLocationPrefix(
         container = "my-azure-container",

--- a/storage/src/test/scala/uk/ac/wellcome/storage/providers/memory/MemoryLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/providers/memory/MemoryLocationTest.scala
@@ -14,6 +14,13 @@ class MemoryLocationTest extends AnyFunSpec with Matchers {
       )
     }
 
+    it("removes double slashes when joining paths") {
+      loc.join("trailing-slash/", "cornish-rex.jpg") shouldBe MemoryLocation(
+        namespace = "my-memory-bukkit",
+        path = "path/to/pictures/trailing-slash/cornish-rex.jpg"
+      )
+    }
+
     it("creates a prefix") {
       loc.asPrefix shouldBe MemoryLocationPrefix(
         namespace = "my-memory-bukkit",

--- a/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
@@ -84,6 +84,13 @@ class S3ObjectLocationTest
         )
       }
 
+      it("removes double slashes when joining paths") {
+        loc.join("trailing-slash/", "cornish-rex.jpg") shouldBe S3ObjectLocation(
+          bucket = "my-s3-bucket",
+          key = "path/to/pictures/trailing-slash/cornish-rex.jpg"
+        )
+      }
+
       it("creates a prefix") {
         loc.asPrefix shouldBe S3ObjectLocationPrefix(
           bucket = "my-s3-bucket",


### PR DESCRIPTION
This causes particular problems in the S3 console if a double slash ends up in a key.  It turns out we already handle this correctly; add a test to ensure we don't accidentally regress this behaviour in future.