### PR TITLE
Encapsulate the DynamoFormat[ExpiringLock] in the lock DAO

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 Remove the implicit DynamoFormat[ExpiringLock] parameter from the lock dao and instead provide it internally, therefore preventing inconsistent formatting.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major
+
+Remove the implicit DynamoFormat[ExpiringLock] parameter from the lock dao and instead provide it internally, therefore preventing inconsistent formatting.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.{DeleteItemResult, PutItemResult}
 import grizzled.slf4j.Logging
 import org.scanamo.query.Condition
+import org.scanamo.semiauto._
 import org.scanamo.syntax._
 import org.scanamo.{DynamoFormat, Table => ScanamoTable}
 import uk.ac.wellcome.storage.locking.{LockDao, LockFailure, UnlockFailure}
@@ -19,10 +20,13 @@ import scala.util.Try
 class DynamoLockDao(
   val client: AmazonDynamoDB,
   config: DynamoLockDaoConfig
-)(implicit val ec: ExecutionContext, val df: DynamoFormat[ExpiringLock])
+)(implicit val ec: ExecutionContext)
     extends LockDao[String, UUID]
     with Logging
     with ScanamoHelpers[ExpiringLock] {
+
+  implicit val df: DynamoFormat[ExpiringLock] =
+    deriveDynamoFormat[ExpiringLock]
 
   override val table: ScanamoTable[ExpiringLock] =
     ScanamoTable[ExpiringLock](config.dynamoConfig.tableName)

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/DynamoLockDaoBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/DynamoLockDaoBuilder.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.storage.typesafe
 
 import com.typesafe.config.Config
-import org.scanamo.DynamoFormat
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDao,
-  DynamoLockDaoConfig,
-  ExpiringLock
+  DynamoLockDaoConfig
 }
 import uk.ac.wellcome.typesafe.config.builders.AWSClientConfigBuilder
 
@@ -15,7 +13,6 @@ object DynamoLockDaoBuilder extends AWSClientConfigBuilder {
   def buildDynamoLockDao(config: Config, namespace: String = "locking")(
     implicit
     ec: ExecutionContext,
-    df: DynamoFormat[ExpiringLock]
   ) = new DynamoLockDao(
     client = DynamoBuilder.buildDynamoClient(config),
     config =

--- a/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
+++ b/storage_typesafe/src/main/scala/uk/ac/wellcome/storage/typesafe/LockingBuilder.scala
@@ -3,8 +3,6 @@ package uk.ac.wellcome.storage.typesafe
 import java.time.Duration
 
 import com.typesafe.config.Config
-import org.scanamo.auto._
-import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDao,
   DynamoLockDaoConfig,


### PR DESCRIPTION
I've put this as a major release because it is technically a breaking change (the implicit will become unused in client code) but could be persuaded to downgrade it