### PR TITLE
Don't warn if you're listing an entire bucket/container

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+### Libraries affected
+
+`storage`
+
+### Description
+
+Make the warning introduced in v19.5.3 a bit less chatty.  In particular, the Listing classes no longer warn if you try to list a prefix with an empty path -- i.e., the complete contents of an S3 bucket or Azure container.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/listing/azure/AzureBlobItemListing.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/listing/azure/AzureBlobItemListing.scala
@@ -15,7 +15,7 @@ class AzureBlobItemListing(implicit blobClient: BlobServiceClient)
     extends AzureListing[BlobItem]
     with Logging {
   override def list(prefix: AzureBlobLocationPrefix): ListingResult = {
-    if (!prefix.namePrefix.endsWith("/")) {
+    if (!prefix.namePrefix.endsWith("/") && prefix.namePrefix != "") {
       warn(
         "Listing an Azure prefix that does not end with a slash " +
           s"($prefix) may return unexpected blobs. " +

--- a/storage/src/main/scala/uk/ac/wellcome/storage/listing/s3/S3ObjectSummaryListing.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/listing/s3/S3ObjectSummaryListing.scala
@@ -15,7 +15,7 @@ class S3ObjectSummaryListing(batchSize: Int = 1000)(
 ) extends S3Listing[S3ObjectSummary]
     with Logging {
   override def list(prefix: S3ObjectLocationPrefix): ListingResult = {
-    if (!prefix.keyPrefix.endsWith("/")) {
+    if (!prefix.keyPrefix.endsWith("/") && prefix.keyPrefix != "") {
       warn(
         "Listing an S3 prefix that does not end with a slash " +
           s"($prefix) may return unexpected objects. " +


### PR DESCRIPTION
I noticed we were dropping this warning log in some storage-service tests, even though a completely empty key/name prefix is a reasonable thing to be listing.

Part of https://github.com/wellcomecollection/platform/issues/4745