### PR TITLE
Bump AKKA from 2.6.4 => 2.6.8

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+### Libraries affected
+
+All
+
+### Description
+
+Bumps the AKKA version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val versions = new {
-    val akka = "2.6.4"
+    val akka = "2.6.8"
     val akkaStreamAlpakka = "1.1.2"
     val elasticApm = "1.12.0"
 


### PR DESCRIPTION
Needed to start using the newer version of Elastic4s.