### PR TITLE
Consolidate the RandomGenerators trait provided by scala-fixtures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major
+
+This release tidies up the random generators provided by `RandomGenerators`.  This trait should be the canonical source of random data for tests in the platform, rather than multiple implementations of very similar functions copy/pasted into different codebases.

--- a/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
@@ -9,14 +9,6 @@ trait RandomGenerators {
   def randomAlphanumeric(length: Int = randomInt(from = 5, to = 10)): String =
     Random.alphanumeric take length mkString
 
-  def randomBytes(length: Int = 1024): Array[Byte] = {
-    val byteArray = new Array[Byte](length)
-
-    Random.nextBytes(byteArray)
-
-    byteArray
-  }
-
   def randomAlphanumericWithSpace(length: Int = 8): String = {
     val str = randomAlphanumeric(length).toCharArray
 
@@ -26,6 +18,24 @@ trait RandomGenerators {
 
     val spaceIndex = Random.nextInt(str.length - 2) + 1
     str.updated(spaceIndex, ' ').toString
+  }
+
+  def randomBytes(length: Int = 1024): Array[Byte] = {
+    val byteArray = new Array[Byte](length)
+
+    Random.nextBytes(byteArray)
+
+    byteArray
+  }
+
+  def randomStringOfByteLength(length: Int): String = {
+    // Generate bytes within UTF-16 mappable range
+    // 0 to 127 maps directly to Unicode code points in the ASCII range
+    val chars = (1 to length).map { _ =>
+      randomInt(from = 97, to = 122).toByte.toChar
+    }
+
+    chars.mkString
   }
 
   def randomUUID: UUID = UUID.randomUUID()

--- a/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import scala.util.Random
 
 trait RandomGenerators {
-  def randomAlphanumeric(length: Int = 8): String =
+  def randomAlphanumeric(length: Int = randomInt(from = 5, to = 10)): String =
     Random.alphanumeric take length mkString
 
   def randomBytes(length: Int = 1024): Array[Byte] = {

--- a/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
@@ -50,6 +50,18 @@ trait RandomGenerators {
     from + randomOffset
   }
 
+  // The slightly unusual default means IntelliJ won't whinge that min=0 is
+  // the default when you use it.
+  def collectionOf[T](
+    min: Int = chooseFrom(0),
+    max: Int = 10)(f: => T): Seq[T] =
+    (1 to randomInt(from = min, to = max)).map { _ =>
+      f
+    }
+
+  def chooseFrom[T](seq: T*): T =
+    seq(Random.nextInt(seq.size))
+
   def randomInstant: Instant =
     Instant.now().plusSeconds(Random.nextInt())
 }

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/MessageSenderTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/MessageSenderTest.scala
@@ -43,10 +43,10 @@ class MessageSenderTest extends AnyFunSpec with Matchers with JsonAssertions wit
       Future(sender.send(body)(subject, destination))
 
     val toSend = Function.tupled(send _)
-    val messageCount = randomInt(from = 50, to = 150)
 
-    val messages = (1 to messageCount).map(i =>
-      (f"$i-${randomAlphanumeric()}", randomAlphanumeric(), randomAlphanumeric()))
+    val messages = collectionOf(min = 50, max = 150) {
+      (randomAlphanumeric(), randomAlphanumeric(), randomAlphanumeric())
+    }
 
     val eventuallyResults = Future.sequence(messages.map(toSend))
     val expectedResults = messages.map(
@@ -54,7 +54,7 @@ class MessageSenderTest extends AnyFunSpec with Matchers with JsonAssertions wit
     ).toSet
 
     whenReady(eventuallyResults) { results =>
-      sender.messages.size shouldBe messageCount
+      sender.messages.size shouldBe messages.size
       results.foreach(_ shouldBe Success(()))
       sender.messages.toSet shouldBe expectedResults
     }

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SNS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SNS.scala
@@ -13,7 +13,6 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{SNSClientFactory, SNSConfig}
 
 import scala.collection.immutable.Seq
-import scala.util.Random
 
 object SNS {
   class Topic(val arn: String) extends AnyVal {
@@ -25,7 +24,7 @@ object SNS {
   }
 }
 
-trait SNS extends Matchers with Logging {
+trait SNS extends Matchers with Logging with RandomGenerators {
 
   import SNS._
 
@@ -43,9 +42,12 @@ trait SNS extends Matchers with Logging {
     secretKey = secretKey
   )
 
+  def createTopicName: String =
+    randomAlphanumeric()
+
   def withLocalSnsTopic[R]: Fixture[Topic, R] = fixture[Topic, R](
     create = {
-      val topicName = Random.alphanumeric take 10 mkString
+      val topicName = createTopicName
       val arn = snsClient
         .createTopic { builder: CreateTopicRequest.Builder =>
           builder.name(topicName)
@@ -69,7 +71,7 @@ trait SNS extends Matchers with Logging {
 
   def withLocalStackSnsTopic[R]: Fixture[Topic, R] = fixture[Topic, R](
     create = {
-      val topicName = Random.alphanumeric take 10 mkString
+      val topicName = createTopicName
       val arn = localStackSnsClient
         .createTopic { builder: CreateTopicRequest.Builder =>
           builder.name(topicName)

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/worker/AlpakkaSQSWorkerFixtures.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/worker/AlpakkaSQSWorkerFixtures.scala
@@ -16,7 +16,6 @@ import uk.ac.wellcome.monitoring.MetricsConfig
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Random
 
 trait AlpakkaSQSWorkerFixtures
     extends WorkerFixtures
@@ -25,8 +24,7 @@ trait AlpakkaSQSWorkerFixtures
     with SQS {
 
   def createAlpakkaSQSWorkerConfig(queue: Queue,
-                                   namespace: String =
-                                     Random.alphanumeric take 10 mkString)
+                                   namespace: String = randomAlphanumeric())
     : AlpakkaSQSWorkerConfig =
     AlpakkaSQSWorkerConfig(
       metricsConfig = MetricsConfig(namespace, flushInterval = 1.second),
@@ -36,7 +34,7 @@ trait AlpakkaSQSWorkerFixtures
   def withAlpakkaSQSWorker[R](
     queue: Queue,
     process: TestInnerProcess,
-    namespace: String = Random.alphanumeric take 10 mkString
+    namespace: String = randomAlphanumeric()
   )(testWith: TestWith[
       (AlpakkaSQSWorker[MyWork, MyContext, MyContext, MySummary],
        AlpakkaSQSWorkerConfig,

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
@@ -23,8 +23,7 @@ class SQSStreamTest
     with IntegrationPatience
     with Eventually
     with SQS
-    with Akka
-    with RandomGenerators {
+    with Akka {
 
   case class NamedObject(name: String)
 

--- a/monitoring/src/test/scala/uk/ac/wellcome/monitoring/cloudwatch/CloudWatchMetricsTest.scala
+++ b/monitoring/src/test/scala/uk/ac/wellcome/monitoring/cloudwatch/CloudWatchMetricsTest.scala
@@ -12,14 +12,13 @@ import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
 import software.amazon.awssdk.services.cloudwatch.model.{PutMetricDataRequest, StandardUnit}
 import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.monitoring.MetricsConfig
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
-import scala.util.Random
 
 class CloudWatchMetricsTest
     extends AnyFunSpec
@@ -28,7 +27,8 @@ class CloudWatchMetricsTest
     with ScalaFutures
     with Eventually
     with Akka
-    with IntegrationPatience {
+    with IntegrationPatience
+    with RandomGenerators {
 
   import org.mockito.Mockito._
 
@@ -134,7 +134,7 @@ class CloudWatchMetricsTest
 
   // TODO: This should use RandomGenerators
   private def createMetricName: String =
-    (Random.alphanumeric take 10 mkString) toLowerCase
+    randomAlphanumeric().toLowerCase()
 
   private def withMetricsSender[R](
     cloudWatchClient: CloudWatchClient)(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/DynamoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/DynamoFixtures.scala
@@ -13,7 +13,6 @@ import uk.ac.wellcome.fixtures._
 import uk.ac.wellcome.storage.dynamo.{DynamoClientFactory, DynamoConfig}
 
 import scala.collection.immutable
-import scala.util.Random
 
 object DynamoFixtures {
   case class Table(name: String, index: String)
@@ -22,7 +21,8 @@ object DynamoFixtures {
 trait DynamoFixtures
     extends Eventually
     with Matchers
-    with IntegrationPatience {
+    with IntegrationPatience
+    with RandomGenerators {
   import DynamoFixtures._
 
   private val port = 45678
@@ -42,8 +42,8 @@ trait DynamoFixtures
 
   def nonExistentTable: Table =
     Table(
-      name = Random.alphanumeric.take(10).mkString,
-      index = Random.alphanumeric.take(10).mkString
+      name = randomAlphanumeric(),
+      index = randomAlphanumeric()
     )
 
   def withSpecifiedLocalDynamoDbTable[R](
@@ -58,8 +58,8 @@ trait DynamoFixtures
   def withSpecifiedTable[R](
     tableDefinition: Table => Table): Fixture[Table, R] = fixture[Table, R](
     create = {
-      val tableName = Random.alphanumeric.take(10).mkString
-      val indexName = Random.alphanumeric.take(10).mkString
+      val tableName = randomAlphanumeric()
+      val indexName = randomAlphanumeric()
 
       tableDefinition(Table(tableName, indexName))
     },

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/LockingServiceFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/LockingServiceFixtures.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.storage.fixtures
 import grizzled.slf4j.Logging
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues, TryValues}
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.locking._
 
 import scala.util.Try
@@ -15,7 +14,7 @@ trait LockingServiceFixtures[Ident, ContextId, LockDaoContext]
     with Matchers
     with Logging
     with LockDaoFixtures[Ident, ContextId, LockDaoContext]
-    with RandomThings {
+    with RandomGenerators {
 
   type LockDaoStub = LockDao[Ident, ContextId]
   type ResultF = Try[Either[FailedLockingServiceOp, String]]
@@ -65,8 +64,8 @@ trait LockingServiceFixtures[Ident, ContextId, LockDaoContext]
     failedLock.e shouldBe e
   }
 
-  val expectedResult: String = randomAlphanumeric
-  val expectedError: Error = new Error(randomAlphanumeric)
+  val expectedResult: String = randomAlphanumeric()
+  val expectedError: Error = new Error(randomAlphanumeric())
 
   def f = Try { expectedResult }
   def fError = Try { throw expectedError }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3Fixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3Fixtures.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
 import uk.ac.wellcome.fixtures._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.generators.{S3ObjectLocationGenerators, StreamGenerators}
 import uk.ac.wellcome.storage.s3.{S3ClientFactory, S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
@@ -34,7 +34,8 @@ trait S3Fixtures
     with IntegrationPatience
     with Matchers
     with EitherValues
-    with S3ObjectLocationGenerators {
+    with S3ObjectLocationGenerators
+    with StreamGenerators {
 
   import S3Fixtures._
 
@@ -54,8 +55,8 @@ trait S3Fixtures
   val brokenS3Client: AmazonS3 = S3ClientFactory.create(
     region = "nuh-uh",
     endpoint = "http://nope.nope",
-    accessKey = randomAlphanumeric,
-    secretKey = randomAlphanumeric
+    accessKey = randomAlphanumeric(),
+    secretKey = randomAlphanumeric()
   )
 
   def withLocalS3Bucket[R]: Fixture[Bucket, R] =
@@ -105,7 +106,7 @@ trait S3Fixtures
 
   def putStream(
     location: S3ObjectLocation,
-    inputStream: InputStreamWithLength = randomInputStream()): Unit = {
+    inputStream: InputStreamWithLength = createInputStream()): Unit = {
     val metadata = new ObjectMetadata()
     metadata.setContentLength(inputStream.length)
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/AzureBlobLocationGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/AzureBlobLocationGenerators.scala
@@ -1,9 +1,11 @@
 package uk.ac.wellcome.storage.generators
 
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
 
-trait AzureBlobLocationGenerators extends RandomThings {
+trait AzureBlobLocationGenerators extends RandomGenerators {
+
   /** Create a valid container name, which means:
     *
     *   - all lowercase
@@ -14,21 +16,22 @@ trait AzureBlobLocationGenerators extends RandomThings {
     *
     */
   def createContainerName: String =
-    randomAlphanumeric.toLowerCase
+    randomAlphanumeric(length = randomInt(from = 3, to = 63))
+      .toLowerCase
 
   def createContainer: Container =
-    Container(randomAlphanumeric)
+    Container(createContainerName)
 
   def createAzureBlobLocationWith(container: Container): AzureBlobLocation =
     AzureBlobLocation(
       container = container.name,
-      name = randomAlphanumeric
+      name = randomAlphanumeric()
     )
 
   def createAzureBlobLocationPrefixWith(container: Container): AzureBlobLocationPrefix =
     AzureBlobLocationPrefix(
       container = container.name,
-      namePrefix = randomAlphanumeric
+      namePrefix = randomAlphanumeric()
     )
 
   def createAzureBlobLocationPrefix: AzureBlobLocationPrefix =

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/MemoryLocationGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/MemoryLocationGenerators.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.storage.generators
 
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.providers.memory.{MemoryLocation, MemoryLocationPrefix}
 
-trait MemoryLocationGenerators extends RandomThings {
+trait MemoryLocationGenerators extends RandomGenerators {
   def createMemoryLocationWith(
-    namespace: String = randomAlphanumeric,
-    path: String = randomAlphanumeric
+    namespace: String = randomAlphanumeric(),
+    path: String = randomAlphanumeric()
   ): MemoryLocation =
     MemoryLocation(
       namespace = namespace,
@@ -16,11 +17,11 @@ trait MemoryLocationGenerators extends RandomThings {
     createMemoryLocationWith()
 
   def createMemoryLocationPrefixWith(
-    namespace: String = randomAlphanumeric
+    namespace: String = randomAlphanumeric()
   ): MemoryLocationPrefix =
     MemoryLocationPrefix(
       namespace = namespace,
-      path = randomAlphanumeric
+      path = randomAlphanumeric()
     )
 
   def createMemoryLocationPrefix: MemoryLocationPrefix =

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
@@ -2,12 +2,12 @@ package uk.ac.wellcome.storage.generators
 
 import java.io.ByteArrayInputStream
 
-import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 import scala.util.Random
 
-trait RandomThings extends Matchers {
+trait RandomThings extends RandomGenerators {
   def randomAlphanumeric: String =
     Random.alphanumeric take 8 mkString
 
@@ -25,16 +25,6 @@ trait RandomThings extends Matchers {
 
   def randomUTF16String = Random.nextString(8)
 
-  def randomInt(from: Int, to: Int) = {
-    val difference = to - from
-
-    assert(difference > 0)
-
-    val randomOffset = Random.nextInt(difference) + 1
-
-    from + randomOffset
-  }
-
   def randomStringOfByteLength(length: Int): String = {
     // Generate bytes within UTF-16 mappable range
     // 0 to 127 maps directly to Unicode code points in the ASCII range
@@ -43,17 +33,6 @@ trait RandomThings extends Matchers {
     }
 
     chars.mkString
-  }
-
-  def randomBytes(length: Int = 20): Array[Byte] = {
-    val byteArray = Array.fill(length)(0.toByte)
-
-    Random.nextBytes(byteArray)
-
-    byteArray.length > 0 shouldBe true
-    byteArray.length shouldBe length
-
-    byteArray
   }
 
   def randomInputStream(length: Int = 256): InputStreamWithLength = {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
@@ -6,16 +6,6 @@ import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
 trait RandomThings extends RandomGenerators {
-  def randomStringOfByteLength(length: Int): String = {
-    // Generate bytes within UTF-16 mappable range
-    // 0 to 127 maps directly to Unicode code points in the ASCII range
-    val chars = (1 to length).map { _ =>
-      randomInt(from = 97, to = 122).toByte.toChar
-    }
-
-    chars.mkString
-  }
-
   def randomInputStream(length: Int = 256): InputStreamWithLength = {
     val bytes = randomBytes(length)
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
@@ -11,20 +11,6 @@ trait RandomThings extends RandomGenerators {
   def randomAlphanumeric: String =
     Random.alphanumeric take 8 mkString
 
-  private val lowercaseLatinAlphabet = ('a' to 'z')
-
-  def randomAlphanumericWithLength(length: Int = 8): String =
-    Random.alphanumeric take length mkString
-
-  def randomLowercaseLatinAlphabetChar = lowercaseLatinAlphabet(
-    Random.nextInt(lowercaseLatinAlphabet.length - 1)
-  )
-
-  def randomLowercaseLatinAlphabetString(n: Int = 8) =
-    (1 to n) map (_ => randomLowercaseLatinAlphabetChar) mkString
-
-  def randomUTF16String = Random.nextString(8)
-
   def randomStringOfByteLength(length: Int): String = {
     // Generate bytes within UTF-16 mappable range
     // 0 to 127 maps directly to Unicode code points in the ASCII range

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RandomThings.scala
@@ -5,12 +5,7 @@ import java.io.ByteArrayInputStream
 import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
-import scala.util.Random
-
 trait RandomThings extends RandomGenerators {
-  def randomAlphanumeric: String =
-    Random.alphanumeric take 8 mkString
-
   def randomStringOfByteLength(length: Int): String = {
     // Generate bytes within UTF-16 mappable range
     // 0 to 127 maps directly to Unicode code points in the ASCII range

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RecordGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RecordGenerators.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.storage.generators
 
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.IdentityKey
 import uk.ac.wellcome.storage.streaming.Codec
@@ -8,16 +9,16 @@ import uk.ac.wellcome.storage.streaming.Codec._
 
 case class Record(name: String)
 
-trait RecordGenerators extends RandomThings with Logging {
+trait RecordGenerators extends RandomGenerators with Logging {
   implicit lazy val codec: Codec[Record] = typeCodec[Record]
 
   val recordCount: (Int, Int) = (100, 200)
 
   def createIdentityKey: IdentityKey =
-    IdentityKey(randomAlphanumeric)
+    IdentityKey(randomAlphanumeric())
 
   def createRecord: Record = {
-    val record = Record(name = randomAlphanumeric)
+    val record = Record(name = randomAlphanumeric())
 
     trace(s"Created Record: $record")
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/RecordGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/RecordGenerators.scala
@@ -12,8 +12,6 @@ case class Record(name: String)
 trait RecordGenerators extends RandomGenerators with Logging {
   implicit lazy val codec: Codec[Record] = typeCodec[Record]
 
-  val recordCount: (Int, Int) = (100, 200)
-
   def createIdentityKey: IdentityKey =
     IdentityKey(randomAlphanumeric())
 
@@ -25,8 +23,6 @@ trait RecordGenerators extends RandomGenerators with Logging {
     record
   }
 
-  def createRecords: Set[Record] = {
-    val (start, end) = recordCount
-    (1 to randomInt(from = start, to = end)).map(_ => createRecord).toSet
-  }
+  def createRecords: Set[Record] =
+    collectionOf(min = 100, max = 200) { createRecord }.toSet
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
@@ -27,7 +27,7 @@ trait S3ObjectLocationGenerators extends RandomGenerators {
           "_" + createBucket,
           randomAlphanumeric().toUpperCase() + createBucket,
           createBucket + randomAlphanumeric().toUpperCase(),
-          Random.alphanumeric.take(100) mkString
+          randomAlphanumeric(length = randomInt(from = 50, to = 100))
         ))
       .head
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/S3ObjectLocationGenerators.scala
@@ -1,18 +1,21 @@
 package uk.ac.wellcome.storage.generators
 
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 import scala.util.Random
 
-trait S3ObjectLocationGenerators extends RandomThings {
+trait S3ObjectLocationGenerators extends RandomGenerators {
+
   def createBucketName: String =
     // Bucket names
     //  - start with a lowercase letter or number,
     //  - do not contain uppercase characters or underscores,
     //  - between 3 and 63 characters in length.
     // [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]
-    randomAlphanumeric.toLowerCase
+    randomAlphanumeric(length = randomInt(from = 3, to = 63))
+      .toLowerCase
 
   def createBucket: Bucket = Bucket(createBucketName)
 
@@ -22,8 +25,8 @@ trait S3ObjectLocationGenerators extends RandomThings {
       .shuffle(
         Seq(
           "_" + createBucket,
-          randomAlphanumeric.toUpperCase() + createBucket,
-          createBucket + randomAlphanumeric.toUpperCase(),
+          randomAlphanumeric().toUpperCase() + createBucket,
+          createBucket + randomAlphanumeric().toUpperCase(),
           Random.alphanumeric.take(100) mkString
         ))
       .head
@@ -33,7 +36,7 @@ trait S3ObjectLocationGenerators extends RandomThings {
   def createS3ObjectLocationWith(bucket: Bucket): S3ObjectLocation =
     S3ObjectLocation(
       bucket = bucket.name,
-      key = randomAlphanumeric
+      key = randomAlphanumeric()
     )
 
   def createS3ObjectLocation: S3ObjectLocation = createS3ObjectLocationWith(bucket = createBucket)
@@ -41,7 +44,7 @@ trait S3ObjectLocationGenerators extends RandomThings {
   def createS3ObjectLocationPrefixWith(bucket: Bucket): S3ObjectLocationPrefix =
     S3ObjectLocationPrefix(
       bucket = bucket.name,
-      keyPrefix = randomAlphanumeric
+      keyPrefix = randomAlphanumeric()
     )
 
   def createS3ObjectLocationPrefix: S3ObjectLocationPrefix =

--- a/storage/src/test/scala/uk/ac/wellcome/storage/generators/StreamGenerators.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/generators/StreamGenerators.scala
@@ -5,8 +5,8 @@ import java.io.ByteArrayInputStream
 import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 
-trait RandomThings extends RandomGenerators {
-  def randomInputStream(length: Int = 256): InputStreamWithLength = {
+trait StreamGenerators extends RandomGenerators {
+  def createInputStream(length: Int = 256): InputStreamWithLength = {
     val bytes = randomBytes(length)
 
     new InputStreamWithLength(new ByteArrayInputStream(bytes), length = length)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/listing/ListingTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/listing/ListingTestCases.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.storage.listing
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.listing.fixtures.ListingFixtures
 
 trait ListingTestCases[Ident,
@@ -14,7 +14,7 @@ trait ListingTestCases[Ident,
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with RandomThings
+    with RandomGenerators
     with ListingFixtures[
       Ident,
       Prefix,
@@ -61,7 +61,7 @@ trait ListingTestCases[Ident,
         withListingContext { implicit context =>
           val ident = createIdent
           val prefix = createPrefixMatching(ident)
-          val entries = Seq(extendIdent(ident, randomAlphanumeric))
+          val entries = Seq(extendIdent(ident, randomAlphanumeric()))
 
           withListing(context, initialEntries = entries) { listing =>
             assertResultCorrect(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/listing/azure/AzureBlobLocationListingTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/listing/azure/AzureBlobLocationListingTest.scala
@@ -5,6 +5,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.azure.{AzureBlobLocation, AzureBlobLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.AzureFixtures
 import uk.ac.wellcome.storage.fixtures.AzureFixtures.Container
+import uk.ac.wellcome.storage.generators.StreamGenerators
 import uk.ac.wellcome.storage.listing.ListingTestCases
 
 class AzureBlobLocationListingTest extends ListingTestCases[
@@ -13,7 +14,8 @@ class AzureBlobLocationListingTest extends ListingTestCases[
   AzureBlobLocation,
   AzureBlobLocationListing,
   Container]
-  with AzureFixtures {
+  with AzureFixtures
+  with StreamGenerators {
 
   override def createIdent(implicit container: Container): AzureBlobLocation =
     createAzureBlobLocationWith(container)
@@ -40,7 +42,7 @@ class AzureBlobLocationListingTest extends ListingTestCases[
       azureClient
         .getBlobContainerClient(location.container)
         .getBlobClient(location.name)
-        .upload(randomInputStream(length = 20), 20)
+        .upload(createInputStream(length = 20), 20)
     }
 
     testWith(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/listing/memory/MemoryListingTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/listing/memory/MemoryListingTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.storage.listing.memory
 
 import org.scalatest.Assertion
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.listing.ListingTestCases
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 
@@ -13,17 +13,17 @@ class MemoryListingTest
       MemoryListing[String, String, Array[Byte]],
       MemoryStore[String, Array[Byte]]]
     with MemoryListingFixtures[Array[Byte]]
-    with RandomThings {
+    with RandomGenerators {
   def createT: Array[Byte] = randomBytes()
 
   override def createIdent(
     implicit context: MemoryStore[String, Array[Byte]]): String =
-    randomAlphanumeric
+    randomAlphanumeric()
 
   override def extendIdent(id: String, extension: String): String =
     id + extension
 
-  override def createPrefix: String = randomAlphanumeric
+  override def createPrefix: String = randomAlphanumeric()
 
   override def createPrefixMatching(id: String): String = id
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
@@ -8,10 +8,9 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
 import org.scalatest.Assertion
 import org.scanamo.auto._
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
-import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.locking.{LockDao, LockDaoFixtures}
 import uk.ac.wellcome.storage.dynamo.DynamoTimeFormat._
 
@@ -20,7 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait DynamoLockDaoFixtures
     extends LockDaoFixtures[String, UUID, Table]
     with DynamoFixtures
-    with RandomThings {
+    with RandomGenerators {
   def createTable(table: Table): Table =
     createLockTable(table)
 
@@ -35,8 +34,8 @@ trait DynamoLockDaoFixtures
       testWith(lockDao)
     }
 
-  override def createIdent: String = randomAlphanumeric
-  override def createContextId: UUID = UUID.randomUUID()
+  override def createIdent: String = randomAlphanumeric()
+  override def createContextId: UUID = UUID.randomUUID()  // TODO: fix this
 
   def assertNoLocks(lockTable: Table): Assertion =
     scanTable[ExpiringLock](lockTable) shouldBe empty

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
 import org.scalatest.Assertion
 import org.scanamo.auto._
-import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.locking.{LockDao, LockDaoFixtures}
@@ -18,8 +18,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait DynamoLockDaoFixtures
     extends LockDaoFixtures[String, UUID, Table]
-    with DynamoFixtures
-    with RandomGenerators {
+    with DynamoFixtures {
   def createTable(table: Table): Table =
     createLockTable(table)
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoFixtures.scala
@@ -35,7 +35,7 @@ trait DynamoLockDaoFixtures
     }
 
   override def createIdent: String = randomAlphanumeric()
-  override def createContextId: UUID = UUID.randomUUID()  // TODO: fix this
+  override def createContextId: UUID = randomUUID
 
   def assertNoLocks(lockTable: Table): Assertion =
     scanTable[ExpiringLock](lockTable) shouldBe empty

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/memory/MemoryLockDaoFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/memory/MemoryLockDaoFixtures.scala
@@ -2,13 +2,12 @@ package uk.ac.wellcome.storage.locking.memory
 
 import java.util.UUID
 
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.locking.{LockDao, LockDaoFixtures}
 
 trait MemoryLockDaoFixtures
     extends LockDaoFixtures[String, UUID, Unit]
-    with RandomThings {
+    with RandomGenerators {
   override def withLockDaoContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
 
@@ -18,6 +17,6 @@ trait MemoryLockDaoFixtures
       new MemoryLockDao[String, UUID]()
     )
 
-  override def createIdent: String = randomAlphanumeric
-  override def createContextId: UUID = UUID.randomUUID()
+  override def createIdent: String = randomAlphanumeric()
+  override def createContextId: UUID = randomUUID
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
@@ -145,11 +145,11 @@ class DynamoHashRangeMaximaTest extends MaximaTestCases with DynamoFixtures {
               Set(
                 WrongEntry(
                   id,
-                  version = randomAlphanumeric,
+                  version = randomAlphanumeric(),
                   record = createRecord),
                 WrongEntry(
                   id,
-                  version = randomAlphanumeric,
+                  version = randomAlphanumeric(),
                   record = createRecord)
               )
             ))

--- a/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/s3/S3ObjectLocationTest.scala
@@ -136,7 +136,7 @@ class S3ObjectLocationTest
 
     it("can be created from an S3ObjectSummary") {
       val bucket = createBucketName
-      val key = randomAlphanumeric
+      val key = randomAlphanumeric()
 
       val summary = new S3ObjectSummary()
       summary.setBucketName(bucket)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/services/LargeStreamReaderTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/services/LargeStreamReaderTestCases.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.storage.services
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.models.ByteRange
 import uk.ac.wellcome.storage.streaming.Codec
 import uk.ac.wellcome.storage.{DoesNotExistError, ReadError, RetryableError, StoreReadError}
@@ -13,7 +12,7 @@ trait LargeStreamReaderTestCases[Ident, Namespace]
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with RandomThings {
+    with RandomGenerators {
   def withNamespace[R](testWith: TestWith[Namespace, R]): R
 
   def createIdentWith(namespace: Namespace): Ident
@@ -42,7 +41,7 @@ trait LargeStreamReaderTestCases[Ident, Namespace]
       val ident = createIdentWith(namespace)
 
       val bufferSize = 500
-      val contents = randomAlphanumericWithLength(length = bufferSize * 3)
+      val contents = randomAlphanumeric(length = bufferSize * 3)
 
       writeString(ident, contents)
 
@@ -63,7 +62,7 @@ trait LargeStreamReaderTestCases[Ident, Namespace]
       val ident = createIdentWith(namespace)
 
       val bufferSize = 500
-      val contents = randomAlphanumericWithLength(length = bufferSize * 3 + 1)
+      val contents = randomAlphanumeric(length = bufferSize * 3 + 1)
 
       writeString(ident, contents)
 
@@ -91,7 +90,7 @@ trait LargeStreamReaderTestCases[Ident, Namespace]
     withNamespace { namespace =>
       val ident = createIdentWith(namespace)
 
-      val contents = randomAlphanumeric
+      val contents = randomAlphanumeric()
       writeString(ident, contents)
 
       var rangedReaderCalls = 0

--- a/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3LargeStreamReaderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3LargeStreamReaderTest.scala
@@ -52,7 +52,7 @@ class S3LargeStreamReaderTest
       val location = createS3ObjectLocationWith(bucket)
       putStream(
         location,
-        inputStream = randomInputStream(length = bufferSize * 2)
+        inputStream = createInputStream(length = bufferSize * 2)
       )
 
       val spyClient = Mockito.spy(s3Client)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3SizeFinderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3SizeFinderTest.scala
@@ -7,12 +7,14 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.DoesNotExistError
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.generators.StreamGenerators
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.services.{SizeFinder, SizeFinderTestCases}
 
 class S3SizeFinderTest
     extends SizeFinderTestCases[S3ObjectLocation, Bucket]
-    with S3Fixtures {
+    with S3Fixtures
+    with StreamGenerators {
 
   override def withContext[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { bucket =>
@@ -53,7 +55,7 @@ class S3SizeFinderTest
     withLocalS3Bucket { bucket =>
       val location = createS3ObjectLocationWith(bucket)
 
-      val inputStream = randomInputStream()
+      val inputStream = createInputStream()
 
       s3Client.putObject(
         new PutObjectRequest(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3UploaderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/services/s3/S3UploaderTest.scala
@@ -18,7 +18,7 @@ class S3UploaderTest extends AnyFunSpec with Matchers with S3Fixtures {
   val uploader = new S3Uploader()
 
   it("creates a pre-signed URL for an object") {
-    val content = randomAlphanumeric
+    val content = randomAlphanumeric()
 
     withLocalS3Bucket { bucket =>
       val url = uploader
@@ -35,7 +35,7 @@ class S3UploaderTest extends AnyFunSpec with Matchers with S3Fixtures {
   }
 
   it("will not update an existing stored object if instructed so") {
-    val content = randomAlphanumeric
+    val content = randomAlphanumeric()
 
     withLocalS3Bucket { bucket =>
       val location = createS3ObjectLocationWith(bucket)
@@ -75,7 +75,7 @@ class S3UploaderTest extends AnyFunSpec with Matchers with S3Fixtures {
   }
 
   it("will update an existing stored object if instructed so") {
-    val content = randomAlphanumeric
+    val content = randomAlphanumeric()
 
     withLocalS3Bucket { bucket =>
       val location = createS3ObjectLocationWith(bucket)
@@ -116,7 +116,7 @@ class S3UploaderTest extends AnyFunSpec with Matchers with S3Fixtures {
   }
 
   it("expires the URL after the given duration") {
-    val content = randomAlphanumeric
+    val content = randomAlphanumeric()
 
     withLocalS3Bucket { bucket =>
       // Picking a good expiryLength here is tricky: too fast and the test becomes
@@ -151,7 +151,7 @@ class S3UploaderTest extends AnyFunSpec with Matchers with S3Fixtures {
     val err = uploader
       .uploadAndGetURL(
         location = createS3ObjectLocation,
-        content = randomAlphanumeric,
+        content = randomAlphanumeric(),
         expiryLength = 5.minutes
       )
       .left

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/HybridStoreTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/HybridStoreTestCases.scala
@@ -4,7 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.storage.generators.StreamGenerators
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 import uk.ac.wellcome.storage._
 
@@ -22,7 +22,7 @@ trait HybridStoreTestCases[IndexedStoreId,
       Namespace,
       HybridStoreContext]
     with Matchers
-    with RandomThings
+    with StreamGenerators
     with EitherValues {
 
   type HybridStoreImpl = HybridStore[IndexedStoreId, TypedStoreId, T]
@@ -208,7 +208,7 @@ trait HybridStoreTestCases[IndexedStoreId,
 
                     val byteLength = 256
                     val inputStream = new InputStreamWithLength(
-                      randomInputStream(byteLength),
+                      createInputStream(byteLength),
                       length = byteLength
                     )
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/TypedStoreTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/TypedStoreTestCases.scala
@@ -2,9 +2,8 @@ package uk.ac.wellcome.storage.store
 
 import java.io.{FilterInputStream, InputStream}
 
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.store.fixtures.TypedStoreFixtures
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.{
@@ -26,7 +25,7 @@ trait TypedStoreTestCases[
       StreamStoreImpl,
       TypedStoreImpl,
       StreamStoreContext]
-    with RandomThings {
+    with RandomGenerators {
 
   override def withStoreImpl[R](
     initialEntries: Map[Ident, T],

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeReadableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeReadableTest.scala
@@ -86,7 +86,7 @@ class DynamoHashRangeReadableTest
     }
 
     it("finds a row with matching hashKey and rangeKey") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
       val record = createRecord
 
       val initialEntries = Set(
@@ -103,7 +103,7 @@ class DynamoHashRangeReadableTest
     }
 
     it("fails if there's a row with matching hash but not range key") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
       val record = createRecord
 
       val initialEntries = Set(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeStoreTest.scala
@@ -45,11 +45,11 @@ class DynamoHashRangeStoreTest
   override def createT: Record = createRecord
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createTable(table: Table): Table =
     createTableWithHashRangeKey(table)
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(id = randomAlphanumeric, version = 1)
+    Version(id = randomAlphanumeric(), version = 1)
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeWritableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeWritableTest.scala
@@ -23,7 +23,7 @@ class DynamoHashRangeWritableTest
     with RecordGenerators {
   type HashRangeEntry = DynamoHashRangeEntry[String, Int, Record]
 
-  def createId: String = randomAlphanumeric
+  def createId: String = randomAlphanumeric()
   def createT: Record = createRecord
 
   class HashRangeWritableImpl(
@@ -66,7 +66,7 @@ class DynamoHashRangeWritableTest
   describe("DynamoHashRangeWritable") {
 
     it("allows putting the same hash key at multiple versions") {
-      val hashKey = randomAlphanumeric
+      val hashKey = randomAlphanumeric()
 
       withLocalDynamoDbTable { table =>
         val writable = createDynamoWritableWith(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashReadableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashReadableTest.scala
@@ -55,7 +55,7 @@ class DynamoHashReadableTest
     }
 
     it("finds a row with matching hashKey and version") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
       val record = createRecord
 
       val initialEntries = Set(
@@ -72,7 +72,7 @@ class DynamoHashReadableTest
     }
 
     it("fails if there is a row with matching hashKey but wrong version") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
       val record = createRecord
 
       val initialEntries = Set(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashStoreTest.scala
@@ -57,13 +57,13 @@ class DynamoHashStoreTest
   override def createT: Record = createRecord
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createTable(table: Table): Table = createTableWithHashKey(table)
 
   override def createId(
     implicit namespace: String): Version[IdentityKey, Int] =
-    Version(id = IdentityKey(randomAlphanumeric), version = 1)
+    Version(id = IdentityKey(randomAlphanumeric()), version = 1)
 
   override def withMaxima[R](
     initialEntries: Map[Version[IdentityKey, Int], Record])(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashWritableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashWritableTest.scala
@@ -24,7 +24,7 @@ class DynamoHashWritableTest
     with RecordGenerators {
   type HashEntry = DynamoHashEntry[String, Int, Record]
 
-  def createId: String = randomAlphanumeric
+  def createId: String = randomAlphanumeric()
   def createT: Record = createRecord
 
   class TestHashWritable(
@@ -62,7 +62,7 @@ class DynamoHashWritableTest
 
   describe("DynamoHashWritable") {
     it("fails to overwrite a new version with an old version") {
-      val hashKey = randomAlphanumeric
+      val hashKey = randomAlphanumeric()
       val olderRecord = createRecord
       val newerRecord = createRecord
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -80,7 +80,7 @@ trait DynamoHybridStoreTestCases[
     testWith(())
 
   override def createId(implicit namespace: Unit): Version[String, Int] =
-    Version(id = randomAlphanumeric, version = 1)
+    Version(id = randomAlphanumeric(), version = randomInt(from = 1, to = 10))
 
   describe("DynamoHybridStore") {
     it("appends a .json suffix to object keys") {
@@ -205,9 +205,6 @@ trait DynamoHybridStoreTestCases[
       it("if the underlying DynamoDB table doesn't exist") {
         withStoreContext {
           case (bucket, _) =>
-            val nonExistentTable =
-              Table(randomAlphanumeric, randomAlphanumeric)
-
             implicit val context = (bucket, nonExistentTable)
 
             withNamespace { implicit namespace =>
@@ -314,8 +311,9 @@ trait DynamoHybridStoreTestCases[
                                         contents: String)
 
                       putTableItem(
-                        BadRow(id.id, id.version, randomAlphanumeric),
-                        table)
+                        item = BadRow(id.id, id.version, randomAlphanumeric()),
+                        table = table
+                      )
 
                       val value = hybridStore.get(id).left.value
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
@@ -16,7 +16,7 @@ class DynamoMultipleVersionStoreTest
     with RecordGenerators
     with DynamoFixtures {
 
-  override def createIdent: String = randomAlphanumeric
+  override def createIdent: String = randomAlphanumeric()
   override def createT: Record = createRecord
 
   type DynamoStoreStub = DynamoMultipleVersionStore[String, Record]
@@ -107,10 +107,10 @@ class DynamoMultipleVersionStoreTest
     withVersionedStoreContext(testWith)
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(randomAlphanumeric, 0)
+    Version(randomAlphanumeric(), 0)
 
   override def withStoreImpl[R](
     initialEntries: Map[Version[String, Int], Record],

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadableTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadableTestCases.scala
@@ -34,7 +34,7 @@ trait DynamoReadableTestCases[
 
   describe("DynamoReadable") {
     it("reads a row from the table") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
       val record = createRecord
 
       val initialEntries = Set(
@@ -55,14 +55,14 @@ trait DynamoReadableTestCases[
         val readable = createDynamoReadableWith(table)
 
         readable
-          .get(Version(randomAlphanumeric, 1))
+          .get(Version(randomAlphanumeric(), 1))
           .left
           .value shouldBe a[DoesNotExistError]
       }
     }
 
     it("finds nothing if there's no row with that hash key") {
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
 
       val initialEntries = Set(
         createEntry(id, v = 1, createRecord)
@@ -72,7 +72,7 @@ trait DynamoReadableTestCases[
         val readable = createDynamoReadableWith(table, initialEntries)
 
         readable
-          .get(Version(randomAlphanumeric, 1))
+          .get(Version(randomAlphanumeric(), 1))
           .left
           .value shouldBe a[DoesNotExistError]
       }
@@ -81,7 +81,7 @@ trait DynamoReadableTestCases[
     it("fails if DynamoDB has an error") {
       val readable = createDynamoReadableWith(nonExistentTable)
 
-      val result = readable.get(Version(randomAlphanumeric, 1))
+      val result = readable.get(Version(randomAlphanumeric(), 1))
       val err = result.left.value.e
 
       err shouldBe a[ResourceNotFoundException]
@@ -93,12 +93,12 @@ trait DynamoReadableTestCases[
       // This doesn't have the payload field that our DynamoEntry model requires
       case class BadModel(id: String, version: Int, t: String)
 
-      val id = randomAlphanumeric
+      val id = randomAlphanumeric()
 
       withLocalDynamoDbTable { table =>
         scanamo.exec(
           ScanamoTable[BadModel](table.name).putAll(
-            Set(BadModel(id, version = 1, t = randomAlphanumeric))
+            Set(BadModel(id, version = 1, t = randomAlphanumeric()))
           ))
 
         val readable = createDynamoReadableWith(table)
@@ -118,7 +118,7 @@ trait DynamoReadableTestCases[
     withSpecifiedTable(createWrongTable) { table =>
       val readable = createDynamoReadableWith(table)
 
-      val result = readable.get(id = Version(randomAlphanumeric, 1))
+      val result = readable.get(id = Version(randomAlphanumeric(), 1))
 
       val err = result.left.value
       err.e shouldBe a[AmazonDynamoDBException]

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
@@ -16,7 +16,7 @@ class DynamoSingleVersionStoreTest
     with RecordGenerators
     with DynamoFixtures {
 
-  override def createIdent: String = randomAlphanumeric
+  override def createIdent: String = randomAlphanumeric()
   override def createT: Record = createRecord
 
   type DynamoStoreStub = DynamoSingleVersionStore[String, Record]
@@ -107,10 +107,10 @@ class DynamoSingleVersionStoreTest
     withVersionedStoreContext(testWith)
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(randomAlphanumeric, 0)
+    Version(randomAlphanumeric(), 0)
 
   override def withStoreImpl[R](
     initialEntries: Map[Version[String, Int], Record],

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
@@ -58,7 +58,7 @@ class DynamoVersionedHybridStoreTest
     }
   }
 
-  override def createIdent: String = randomAlphanumeric
+  override def createIdent: String = randomAlphanumeric()
 
   override def createT: Record = createRecord
 
@@ -115,8 +115,8 @@ class DynamoVersionedHybridStoreTest
     withVersionedStoreContext(testWith)
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(randomAlphanumeric, 0)
+    Version(randomAlphanumeric(), 0)
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/NamespaceFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/NamespaceFixtures.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.storage.store.fixtures
 
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 trait NamespaceFixtures[Ident, Namespace] {
@@ -14,12 +13,12 @@ trait NamespaceFixtures[Ident, Namespace] {
 
 trait StringNamespaceFixtures
     extends NamespaceFixtures[String, String]
-    with RandomThings {
+    with RandomGenerators {
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): String =
-    s"$namespace/$randomAlphanumeric"
+    s"$namespace/${randomAlphanumeric()}"
 }
 
 trait S3NamespaceFixtures

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/ReplayableStreamFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/ReplayableStreamFixtures.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.storage.store.fixtures
 
 import org.scalatest.EitherValues
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.streaming.Codec.bytesCodec
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
-import uk.ac.wellcome.storage.generators.RandomThings
 
-trait ReplayableStreamFixtures extends EitherValues with RandomThings {
+trait ReplayableStreamFixtures extends EitherValues with RandomGenerators {
   // In the StoreTestCases, we need to assert that PUT and then GET returns an equivalent
   // value.  A regular InputStream gets consumed on the initial PUT, so we wrap it in
   // a ReplayableStream so we can do comparisons later.

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
@@ -72,7 +72,7 @@ class MemoryHybridStoreTest
   override def withNamespace[R](testWith: TestWith[String, R]): R =
     testWith(randomAlphanumeric())
 
-  override def createId(implicit namespace: String): UUID = UUID.randomUUID()
+  override def createId(implicit namespace: String): UUID = randomUUID
 
   override def withBrokenPutTypedStoreImpl[R](
     testWith: TestWith[MemoryTypedStoreImpl, R])(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
@@ -54,7 +54,7 @@ class MemoryHybridStoreTest
   }
 
   override def createTypedStoreId(implicit namespace: String): String =
-    s"$namespace/$randomAlphanumeric"
+    s"$namespace/${randomAlphanumeric()}"
 
   override def withStoreContext[R](testWith: TestWith[Context, R]): R = {
     implicit val underlyingStreamStore: MemoryStreamStore[String] =
@@ -70,7 +70,7 @@ class MemoryHybridStoreTest
   override def createT: Record = createRecord
     
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): UUID = UUID.randomUUID()
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryStoreFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryStoreFixtures.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.storage.store.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.generators.RandomThings
 import uk.ac.wellcome.storage.store.fixtures.StoreFixtures
 
 trait MemoryStoreFixtures[Ident, T, Namespace]
-    extends StoreFixtures[Ident, T, Namespace, MemoryStore[Ident, T]]
-    with RandomThings {
+    extends StoreFixtures[Ident, T, Namespace, MemoryStore[Ident, T]] {
 
   override def withStoreImpl[R](initialEntries: Map[Ident, T],
                                 storeContext: MemoryStore[Ident, T])(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
@@ -48,7 +48,7 @@ class MemoryVersionedHybridStoreTest
     }
   }
 
-  override def createIdent: String = randomAlphanumeric
+  override def createIdent: String = randomAlphanumeric()
 
   override def withVersionedStoreImpl[R](
     initialEntries: Entries,
@@ -98,8 +98,8 @@ class MemoryVersionedHybridStoreTest
     withVersionedStoreContext(testWith)
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(randomAlphanumeric, 0)
+    Version(randomAlphanumeric(), 0)
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
@@ -17,7 +17,7 @@ class MemoryVersionedStoreTest
   type UnderlyingMemoryStore =
     MemoryStore[Version[String, Int], Record] with MemoryMaxima[String, Record]
 
-  override def createIdent: String = randomAlphanumeric
+  override def createIdent: String = randomAlphanumeric()
   override def createT: Record = createRecord
 
   override def withVersionedStoreImpl[R](initialEntries: Entries)(
@@ -77,10 +77,10 @@ class MemoryVersionedStoreTest
     withVersionedStoreContext(testWith)
 
   override def withNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createId(implicit namespace: String): Version[String, Int] =
-    Version(randomAlphanumeric, 0)
+    Version(randomAlphanumeric(), 0)
 
   override def withStoreImpl[R](
     initialEntries: Map[Version[String, Int], Record],

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/CodecTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/CodecTest.scala
@@ -4,8 +4,8 @@ import io.circe.Json
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.storage.generators.RandomThings
 
 import scala.util.Random
 
@@ -13,7 +13,7 @@ class CodecTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with RandomThings {
+    with RandomGenerators {
 
   import Codec._
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/CodecTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/CodecTest.scala
@@ -7,8 +7,6 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil._
 
-import scala.util.Random
-
 class CodecTest
     extends AnyFunSpec
     with Matchers
@@ -28,14 +26,14 @@ class CodecTest
         }
 
         it("a string") {
-          val randomString = Random.nextString(8)
+          val randomString = randomAlphanumeric()
 
           val stream = stringCodec.toStream(randomString).right.value
           stringCodec.fromStream(stream).right.value shouldBe randomString
         }
 
         it("some json") {
-          val randomString = Random.nextString(8)
+          val randomString = randomAlphanumeric()
           val randomJson = Json.fromString(randomString)
 
           val stream = jsonCodec.toStream(randomJson).right.value
@@ -44,7 +42,7 @@ class CodecTest
 
         it("a type T") {
           case class NamedThing(name: String, value: Int)
-          val thing = NamedThing(name = Random.nextString(8), value = 5)
+          val thing = NamedThing(name = randomAlphanumeric(), value = 5)
 
           val stream = typeCodec[NamedThing].toStream(thing).right.value
           typeCodec[NamedThing].fromStream(stream).right.value shouldBe thing

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/DecoderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/DecoderTest.scala
@@ -11,9 +11,9 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.generators.RandomThings
 
 import scala.util.Random
 
@@ -21,7 +21,7 @@ class DecoderTest
     extends AnyFunSpec
     with EitherValues
     with Matchers
-    with RandomThings {
+    with RandomGenerators {
 
   import DecoderInstances._
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/DecoderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/DecoderTest.scala
@@ -15,8 +15,6 @@ import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage._
 
-import scala.util.Random
-
 class DecoderTest
     extends AnyFunSpec
     with EitherValues
@@ -50,7 +48,7 @@ class DecoderTest
       }
 
       it("a string") {
-        val randomString = Random.nextString(8)
+        val randomString = randomAlphanumeric()
         val randomStream = createStream(randomString)
 
         stringDecoder.fromStream(randomStream) shouldBe Right(randomString)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/EncoderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/EncoderTest.scala
@@ -8,9 +8,9 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil.{toJson, _}
 import uk.ac.wellcome.storage.JsonEncodingError
-import uk.ac.wellcome.storage.generators.RandomThings
 
 import scala.util.Random
 
@@ -18,7 +18,7 @@ class EncoderTest
     extends AnyFunSpec
     with EitherValues
     with Matchers
-    with RandomThings
+    with RandomGenerators
     with StreamAssertions {
 
   import EncoderInstances._

--- a/storage/src/test/scala/uk/ac/wellcome/storage/streaming/EncoderTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/streaming/EncoderTest.scala
@@ -12,8 +12,6 @@ import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.json.JsonUtil.{toJson, _}
 import uk.ac.wellcome.storage.JsonEncodingError
 
-import scala.util.Random
-
 class EncoderTest
     extends AnyFunSpec
     with EitherValues
@@ -35,7 +33,7 @@ class EncoderTest
       }
 
       it("a string") {
-        val randomString = Random.nextString(8)
+        val randomString = randomAlphanumeric()
         val stream = stringEncoder.toStream(randomString)
 
         assertStreamEquals(
@@ -45,7 +43,7 @@ class EncoderTest
       }
 
       it("some json") {
-        val randomString = Random.nextString(8)
+        val randomString = randomAlphanumeric()
         val randomJson = Json.fromString(randomString)
 
         val stream = jsonEncoder.toStream(randomJson)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
@@ -5,15 +5,15 @@ import java.util.UUID
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.tags.memory.MemoryTags
 import uk.ac.wellcome.storage._
 
-class TagsTest extends AnyFunSpec with Matchers with EitherValues with RandomThings {
+class TagsTest extends AnyFunSpec with Matchers with EitherValues with RandomGenerators {
   def createTags: Map[String, String] =
     (1 to randomInt(from = 0, to = 25))
       .map { _ =>
-        randomAlphanumeric -> randomAlphanumeric
+        randomAlphanumeric() -> randomAlphanumeric()
       }
       .toMap
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
@@ -17,7 +17,7 @@ class TagsTest extends AnyFunSpec with Matchers with EitherValues with RandomGen
       }
       .toMap
 
-  def createIdent: UUID = UUID.randomUUID()
+  def createIdent: UUID = randomUUID
 
   describe("update()") {
     it("wraps a ReadError from the underlying store") {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -11,15 +11,9 @@ trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with Either
 
   def createIdent(context: Context): Ident
 
-  val maxTags: Int = 25
-
   // One less than maxTags so we can append to the tags further down
   def createTags: Map[String, String] =
-    (1 to randomInt(from = 0, to = maxTags - 1))
-      .map { _ =>
-        randomAlphanumeric() -> randomAlphanumeric()
-      }
-      .toMap
+    collectionOf(min = 0, max = 24) { randomAlphanumeric() -> randomAlphanumeric() }.toMap
 
   def withContext[R](testWith: TestWith[Context, R]): R
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -3,11 +3,10 @@ package uk.ac.wellcome.storage.tags
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.storage.{DoesNotExistError, Identified, UpdateNoSourceError, UpdateNotApplied}
-import uk.ac.wellcome.storage.generators.RandomThings
 
-trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with EitherValues with RandomThings {
+trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with EitherValues with RandomGenerators {
   def withTags[R](initialTags: Map[Ident, Map[String, String]])(testWith: TestWith[Tags[Ident], R]): R
 
   def createIdent(context: Context): Ident
@@ -18,7 +17,7 @@ trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with Either
   def createTags: Map[String, String] =
     (1 to randomInt(from = 0, to = maxTags - 1))
       .map { _ =>
-        randomAlphanumeric -> randomAlphanumeric
+        randomAlphanumeric() -> randomAlphanumeric()
       }
       .toMap
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -11,9 +11,11 @@ trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with Either
 
   def createIdent(context: Context): Ident
 
+  val maxTags: Int = 25
+
   // One less than maxTags so we can append to the tags further down
   def createTags: Map[String, String] =
-    collectionOf(min = 0, max = 24) { randomAlphanumeric() -> randomAlphanumeric() }.toMap
+    collectionOf(min = 0, max = maxTags) { randomAlphanumeric() -> randomAlphanumeric() }.toMap
 
   def withContext[R](testWith: TestWith[Context, R]): R
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
@@ -11,7 +11,7 @@ class MemoryTagsTest extends TagsTestCases[UUID, Unit] {
       new MemoryTags(initialTags)
     )
 
-  override def createIdent(context: Unit): UUID = UUID.randomUUID()
+  override def createIdent(context: Unit): UUID = randomUUID
 
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
@@ -108,7 +108,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[S3ObjectLoc
         val result =
           s3Tags
             .update(location) { existingTags: Map[String, String] =>
-              Right(existingTags ++ Map(randomAlphanumericWithLength(129) -> "value"))
+              Right(existingTags ++ Map(randomAlphanumeric(length = 129) -> "value"))
             }
 
         assertIsS3Exception(result) {
@@ -127,7 +127,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[S3ObjectLoc
         val result: s3Tags.UpdateEither =
           s3Tags
             .update(location) { existingTags: Map[String, String] =>
-              Right(existingTags ++ Map("key" -> randomAlphanumericWithLength(257)))
+              Right(existingTags ++ Map("key" -> randomAlphanumeric(length = 257)))
             }
 
         assertIsS3Exception(result) {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/azure/AzurePutBlockTransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/azure/AzurePutBlockTransferTest.scala
@@ -39,7 +39,7 @@ class AzurePutBlockTransferTest
   // Deliberately create quite a large record, so we can test the ability of
   // the Transfer object to join multiple blocks together.
   override def createT: Record =
-    Record(name = randomAlphanumericWithLength(length = blockSize * 10))
+    Record(name = randomAlphanumeric(length = blockSize * 10))
 
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 
@@ -141,7 +141,7 @@ class AzurePutBlockTransferTest
           val src = createSrcLocation(srcNamespace)
           val dst = createDstLocation(dstNamespace)
 
-          val t = Record(randomAlphanumericWithLength(length = blockSize * 10))
+          val t = Record(randomAlphanumeric(length = blockSize * 10))
 
           withContext { implicit context =>
             withSrcStore(initialEntries = Map(src -> t)) { srcStore =>
@@ -168,8 +168,7 @@ class AzurePutBlockTransferTest
           val dst = createDstLocation(dstNamespace)
 
           assert(blockSize > 1)
-          val t =
-            Record(randomAlphanumericWithLength(length = blockSize * 10 + 1))
+          val t = Record(randomAlphanumeric(length = blockSize * 10 + 1))
 
           withContext { implicit context =>
             withSrcStore(initialEntries = Map(src -> t)) { srcStore =>

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/azure/AzureTransferFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/azure/AzureTransferFixtures.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.storage.transfer.azure
 
 import com.amazonaws.services.s3.model.S3ObjectSummary
-import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
-trait AzureTransferFixtures extends RandomThings {
+trait AzureTransferFixtures extends RandomGenerators {
   def createS3ObjectSummaryFrom(
     location: S3ObjectLocation,
     size: Long = randomInt(from = 1, to = 50)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryPrefixTransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryPrefixTransferTest.scala
@@ -24,10 +24,10 @@ class MemoryPrefixTransferTest
     MemoryStore[MemoryLocation, Record] with MemoryPrefixTransfer[MemoryLocation, MemoryLocationPrefix, Record]
 
   override def withSrcNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def withDstNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def createSrcLocation(srcNamespace: String): MemoryLocation =
     createMemoryLocationWith(srcNamespace)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransferTest.scala
@@ -24,10 +24,10 @@ class MemoryTransferTest
   override def createT: Array[Byte] = randomBytes()
 
   override def withSrcNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def withDstNamespace[R](testWith: TestWith[String, R]): R =
-    testWith(randomAlphanumeric)
+    testWith(randomAlphanumeric())
 
   override def withContext[R](testWith: TestWith[MemoryStoreContext, R]): R =
     withTransferStore(initialEntries = Map.empty) { store =>


### PR DESCRIPTION
First part of https://github.com/wellcomecollection/platform/issues/4827

Mostly I took RandomThings from _storage_ and collapsed it into RandomGenerators (deleting parts that we no longer use or need), then tidied up all the places where RandomThings was previously used.

I brought in a few extra methods that have been useful in the storage-service and catalogue (`chooseFrom`, `collectionOf`), so we don't have them defined in multiple places.

I will pick up applying this across catalogue and storage-service once this is merged.