### PR TITLE
Fix a flaky test in S3TagsTest

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a flaky test in S3TagsTest.

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -15,7 +15,7 @@ trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with Either
 
   // One less than maxTags so we can append to the tags further down
   def createTags: Map[String, String] =
-    collectionOf(min = 0, max = maxTags) { randomAlphanumeric() -> randomAlphanumeric() }.toMap
+    collectionOf(min = 0, max = maxTags - 1) { randomAlphanumeric() -> randomAlphanumeric() }.toMap
 
   def withContext[R](testWith: TestWith[Context, R]): R
 


### PR DESCRIPTION
We should create 1 less than the max tags, not max tags -- otherwise we'll be unable to append tags in the S3 test.

This is breaking #52.