### PR TITLE
Allow consistency to be set from DynamoSingleVersionStore, DynamoMultipleVersionStore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Allow consistency to be set from DynamoSingleVersionStore, DynamoMultipleVersionStore

--- a/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.storage.dynamo
 import javax.naming.ConfigurationException
 
 case class DynamoConfig(tableName: String,
-                        maybeIndexName: Option[String] = None
-                       ) {
+                        maybeIndexName: Option[String] = None) {
   def indexName: String = maybeIndexName.getOrElse(
     throw new ConfigurationException(
       "Tried to look up the index, but no index is configured!"

--- a/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.storage.dynamo
 
 import javax.naming.ConfigurationException
-import uk.ac.wellcome.storage.store.dynamo.{ConsistencyMode, EventuallyConsistent}
 
 case class DynamoConfig(tableName: String,
-                        maybeIndexName: Option[String] = None,
-                        consistencyMode: ConsistencyMode = EventuallyConsistent
+                        maybeIndexName: Option[String] = None
                        ) {
   def indexName: String = maybeIndexName.getOrElse(
     throw new ConfigurationException(

--- a/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/dynamo/DynamoConfig.scala
@@ -1,9 +1,12 @@
 package uk.ac.wellcome.storage.dynamo
 
 import javax.naming.ConfigurationException
+import uk.ac.wellcome.storage.store.dynamo.{ConsistencyMode, EventuallyConsistent}
 
 case class DynamoConfig(tableName: String,
-                        maybeIndexName: Option[String] = None) {
+                        maybeIndexName: Option[String] = None,
+                        consistencyMode: ConsistencyMode = EventuallyConsistent
+                       ) {
   def indexName: String = maybeIndexName.getOrElse(
     throw new ConfigurationException(
       "Tried to look up the index, but no index is configured!"

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -16,7 +16,8 @@ class DynamoHashRangeStore[HashKey, RangeKey, T](val config: DynamoConfig)(
   implicit val client: AmazonDynamoDB,
   val formatHashKey: DynamoFormat[HashKey],
   val formatRangeKey: DynamoFormat[RangeKey],
-  val format: DynamoFormat[DynamoHashRangeEntry[HashKey, RangeKey, T]]
+  val format: DynamoFormat[DynamoHashRangeEntry[HashKey, RangeKey, T]],
+  override val consistencyMode: ConsistencyMode = EventuallyConsistent
 ) extends Store[Version[HashKey, RangeKey], T]
   with DynamoHashRangeReadable[HashKey, RangeKey, T]
   with DynamoHashRangeWritable[HashKey, RangeKey, T]
@@ -24,9 +25,6 @@ class DynamoHashRangeStore[HashKey, RangeKey, T](val config: DynamoConfig)(
     HashKey,
     RangeKey,
     DynamoHashRangeEntry[HashKey, RangeKey, T]] {
-
-  override protected val consistencyMode =
-    config.consistencyMode
 
   override protected val table =
     Table[DynamoHashRangeEntry[HashKey, RangeKey, T]](config.tableName)
@@ -37,7 +35,8 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
   implicit val client: AmazonDynamoDB,
   val formatHashKey: DynamoFormat[HashKey],
   val formatV: DynamoFormat[V],
-  val format: DynamoFormat[DynamoHashEntry[HashKey, V, T]]
+  val format: DynamoFormat[DynamoHashEntry[HashKey, V, T]],
+  override val consistencyMode: ConsistencyMode = EventuallyConsistent
 ) extends Store[Version[HashKey, V], T]
     with DynamoHashReadable[HashKey, V, T]
     with DynamoHashWritable[HashKey, V, T]
@@ -48,9 +47,6 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
       case Left(err)                  => Left(err)
     }
-
-  override protected val consistencyMode =
-    config.consistencyMode
 
   override protected val table =
     Table[DynamoHashEntry[HashKey, V, T]](config.tableName)

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -18,12 +18,15 @@ class DynamoHashRangeStore[HashKey, RangeKey, T](val config: DynamoConfig)(
   val formatRangeKey: DynamoFormat[RangeKey],
   val format: DynamoFormat[DynamoHashRangeEntry[HashKey, RangeKey, T]]
 ) extends Store[Version[HashKey, RangeKey], T]
-    with DynamoHashRangeReadable[HashKey, RangeKey, T]
-    with DynamoHashRangeWritable[HashKey, RangeKey, T]
-    with DynamoHashRangeMaxima[
-      HashKey,
-      RangeKey,
-      DynamoHashRangeEntry[HashKey, RangeKey, T]] {
+  with DynamoHashRangeReadable[HashKey, RangeKey, T]
+  with DynamoHashRangeWritable[HashKey, RangeKey, T]
+  with DynamoHashRangeMaxima[
+    HashKey,
+    RangeKey,
+    DynamoHashRangeEntry[HashKey, RangeKey, T]] {
+
+  override protected val consistencyMode =
+    config.consistencyMode
 
   override protected val table =
     Table[DynamoHashRangeEntry[HashKey, RangeKey, T]](config.tableName)
@@ -45,6 +48,9 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
       case Left(err)                  => Left(err)
     }
+
+  override protected val consistencyMode =
+    config.consistencyMode
 
   override protected val table =
     Table[DynamoHashEntry[HashKey, V, T]](config.tableName)


### PR DESCRIPTION
Allows consistency mode to be set in config, in turn allowing DynamoSingleVersionStore, DynamoMultipleVersionStore to have more easily configured consistency.

Helps with https://github.com/wellcomecollection/platform/issues/4873