### PR TITLE
Use GetItem instead of Query in the DynamoDB stores

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve the efficiency of reading items from the Dynamo stores.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadable.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadable.scala
@@ -93,7 +93,8 @@ trait DynamoHashRangeReadable[HashKey, RangeKey, T]
   implicit val formatHashKey: DynamoFormat[HashKey]
   implicit val formatRangeKey: DynamoFormat[RangeKey]
 
-  protected def createKeyExpression(id: Version[HashKey, RangeKey]): UniqueKey[_] =
+  protected def createKeyExpression(
+    id: Version[HashKey, RangeKey]): UniqueKey[_] =
     'id -> id.id and 'version -> id.version
 
   override def get(id: Version[HashKey, RangeKey]): ReadEither =

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeReadableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashRangeReadableTest.scala
@@ -80,7 +80,7 @@ class DynamoHashRangeReadableTest
       it("range key is missing") {
         assertErrorsOnWrongTableDefinition(
           table => createTableWithHashKey(table),
-          message = "Query key condition not supported"
+          message = "The number of conditions on the keys is invalid"
         )
       }
     }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashReadableTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHashReadableTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.storage.store.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{QueryRequest, ScalarAttributeType}
+import com.amazonaws.services.dynamodbv2.model.{GetItemRequest, ScalarAttributeType}
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scanamo.{DynamoFormat, Table => ScanamoTable}
@@ -144,8 +144,8 @@ class DynamoHashReadableTest
     }
 
     def getConsistentReadOnQuery(mockClient: AmazonDynamoDB): Boolean = {
-      val captor = ArgumentCaptor.forClass(classOf[QueryRequest])
-      Mockito.verify(mockClient).query(captor.capture())
+      val captor = ArgumentCaptor.forClass(classOf[GetItemRequest])
+      Mockito.verify(mockClient).getItem(captor.capture())
       captor.getValue.getConsistentRead
     }
   }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadableTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoReadableTestCases.scala
@@ -128,11 +128,11 @@ trait DynamoReadableTestCases[
   def assertErrorsOnBadKeyName(createWrongTable: Table => Table): Assertion =
     assertErrorsOnWrongTableDefinition(
       createWrongTable,
-      message = "Query condition missed key schema element")
+      message = "One of the required keys was not given a value")
 
   def assertErrorsOnBadKeyType(createWrongTable: Table => Table): Assertion =
     assertErrorsOnWrongTableDefinition(
       createWrongTable,
       message =
-        "One or more parameter values were invalid: Condition parameter type does not match schema type")
+        "Type mismatch for attribute to update")
 }


### PR DESCRIPTION
It's hard to be sure, but GetItem cannot be slower than Query (and I suspect involves a bit less work on DynamoDB's side). Given we can swap it out and everything works the same, we might as well.