### PR TITLE
Make a single call to DynamoDB in getLatest(), not two

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: major
+
+This release changes the behaviour of Maxima to return an `Identified[_, _]`, rather than a single value.
+This reduces doing double-lookups if you want to get the max version of something in a store, and retrieve the whole record rather than just the max version.
+
+The practical upshot for our code is that if you call `getLatest(…)`, now you're making a single request to DynamoDB rather than two.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/Maxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/Maxima.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.storage.maxima
 
-import uk.ac.wellcome.storage.ReadError
+import uk.ac.wellcome.storage.{Identified, ReadError}
 
-trait Maxima[QueryParameter, Id] {
-  def max(q: QueryParameter): Either[ReadError, Id]
+trait Maxima[QueryParameter, Id, T] {
+  type MaxEither = Either[ReadError, Identified[Id, T]]
+
+  def max(q: QueryParameter): MaxEither
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
@@ -5,7 +5,12 @@ import org.scanamo.syntax._
 import org.scanamo.{DynamoFormat, Scanamo, Table}
 import uk.ac.wellcome.storage.dynamo.DynamoHashRangeEntry
 import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.{Identified, MaximaReadError, NoMaximaValueError, Version}
+import uk.ac.wellcome.storage.{
+  Identified,
+  MaximaReadError,
+  NoMaximaValueError,
+  Version
+}
 
 import scala.util.{Failure, Success, Try}
 
@@ -14,7 +19,8 @@ trait DynamoHashRangeMaxima[HashKey, RangeKey, T]
 
   implicit protected val formatHashKey: DynamoFormat[HashKey]
   implicit protected val formatRangeKey: DynamoFormat[RangeKey]
-  implicit protected val format: DynamoFormat[DynamoHashRangeEntry[HashKey, RangeKey, T]]
+  implicit protected val format: DynamoFormat[
+    DynamoHashRangeEntry[HashKey, RangeKey, T]]
 
   protected val client: AmazonDynamoDB
   protected val table: Table[DynamoHashRangeEntry[HashKey, RangeKey, T]]

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
@@ -3,30 +3,30 @@ package uk.ac.wellcome.storage.maxima.dynamo
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.scanamo.syntax._
 import org.scanamo.{DynamoFormat, Scanamo, Table}
-import uk.ac.wellcome.storage.dynamo.DynamoHashRangeKeyPair
+import uk.ac.wellcome.storage.dynamo.DynamoHashRangeEntry
 import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.{MaximaError, MaximaReadError, NoMaximaValueError}
+import uk.ac.wellcome.storage.{Identified, MaximaReadError, NoMaximaValueError, Version}
 
 import scala.util.{Failure, Success, Try}
 
-trait DynamoHashRangeMaxima[
-  HashKey, RangeKey, Row <: DynamoHashRangeKeyPair[HashKey, RangeKey]]
-    extends Maxima[HashKey, RangeKey] {
+trait DynamoHashRangeMaxima[HashKey, RangeKey, T]
+    extends Maxima[HashKey, Version[HashKey, RangeKey], T] {
 
   implicit protected val formatHashKey: DynamoFormat[HashKey]
   implicit protected val formatRangeKey: DynamoFormat[RangeKey]
-  implicit protected val format: DynamoFormat[Row]
+  implicit protected val format: DynamoFormat[DynamoHashRangeEntry[HashKey, RangeKey, T]]
 
   protected val client: AmazonDynamoDB
-  protected val table: Table[Row]
+  protected val table: Table[DynamoHashRangeEntry[HashKey, RangeKey, T]]
 
-  override def max(hashKey: HashKey): Either[MaximaError, RangeKey] = {
+  override def max(hashKey: HashKey): MaxEither = {
     val ops = table.descending
       .limit(1)
       .query('id -> hashKey)
 
     Try(Scanamo(client).exec(ops)) match {
-      case Success(List(Right(entry))) => Right(entry.rangeKey)
+      case Success(List(Right(row))) =>
+        Right(Identified(Version(row.hashKey, row.rangeKey), row.payload))
       case Success(List(Left(err))) =>
         val error = new Error(s"DynamoReadError: ${err.toString}")
         Left(MaximaReadError(error))

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/memory/MemoryMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/memory/MemoryMaxima.scala
@@ -2,12 +2,17 @@ package uk.ac.wellcome.storage.maxima.memory
 
 import uk.ac.wellcome.storage.maxima.Maxima
 import uk.ac.wellcome.storage.store.memory.MemoryStoreBase
-import uk.ac.wellcome.storage.{MaximaError, NoMaximaValueError, Version}
+import uk.ac.wellcome.storage.{
+  Identified,
+  NoMaximaValueError,
+  Version
+}
 
 trait MemoryMaxima[Id, T]
-    extends Maxima[Id, Int]
+    extends Maxima[Id, Version[Id, Int], T]
     with MemoryStoreBase[Version[Id, Int], T] {
-  def max(id: Id): Either[MaximaError, Int] = {
+
+  def max(id: Id): MaxEither = {
     val matchingEntries =
       entries
         .filter { case (ident, _) => ident.id == id }
@@ -15,9 +20,9 @@ trait MemoryMaxima[Id, T]
     if (matchingEntries.isEmpty) {
       Left(NoMaximaValueError())
     } else {
-      val (maxIdent, _) =
+      val (maxIdent, maxT) =
         matchingEntries.maxBy { case (ident, _) => ident.version }
-      Right(maxIdent.version)
+      Right(Identified(maxIdent, maxT))
     }
   }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/memory/MemoryMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/memory/MemoryMaxima.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.storage.maxima.memory
 
 import uk.ac.wellcome.storage.maxima.Maxima
 import uk.ac.wellcome.storage.store.memory.MemoryStoreBase
-import uk.ac.wellcome.storage.{
-  Identified,
-  NoMaximaValueError,
-  Version
-}
+import uk.ac.wellcome.storage.{Identified, NoMaximaValueError, Version}
 
 trait MemoryMaxima[Id, T]
     extends Maxima[Id, Version[Id, Int], T]

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
@@ -13,8 +13,7 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
   override def max(id: Id): MaxEither =
     indexedStore
       .max(id)
-      .map { case Identified(Version(_, version), typedStoreId) => (version, typedStoreId) }
-      .flatMap { case (version, typedStoreId) =>
+      .flatMap { case Identified(Version(_, version), typedStoreId) =>
         typedStore
           .get(typedStoreId)
           .map { case Identified(_, t) => Identified(Version(id, version), t) }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
@@ -7,15 +7,19 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
     extends HybridStore[Version[Id, V], TypedStoreId, T]
     with Maxima[Id, Version[Id, V], T] {
 
-  override implicit protected val indexedStore:
-    Store[Version[Id, V], TypedStoreId] with Maxima[Id, Version[Id, V], TypedStoreId]
+  override implicit protected val indexedStore: Store[
+    Version[Id, V],
+    TypedStoreId] with Maxima[Id, Version[Id, V], TypedStoreId]
 
   override def max(id: Id): MaxEither =
     indexedStore
       .max(id)
-      .flatMap { case Identified(Version(_, version), typedStoreId) =>
-        typedStore
-          .get(typedStoreId)
-          .map { case Identified(_, t) => Identified(Version(id, version), t) }
+      .flatMap {
+        case Identified(Version(_, version), typedStoreId) =>
+          typedStore
+            .get(typedStoreId)
+            .map {
+              case Identified(_, t) => Identified(Version(id, version), t)
+            }
       }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
@@ -1,15 +1,22 @@
 package uk.ac.wellcome.storage.store
 
-import uk.ac.wellcome.storage.{ReadError, Version}
+import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.storage.maxima.Maxima
 
 trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
     extends HybridStore[Version[Id, V], TypedStoreId, T]
-    with Maxima[Id, V] {
+    with Maxima[Id, Version[Id, V], T] {
 
-  override implicit protected val indexedStore: Store[
-    Version[Id, V],
-    TypedStoreId] with Maxima[Id, V]
+  override implicit protected val indexedStore:
+    Store[Version[Id, V], TypedStoreId] with Maxima[Id, Version[Id, V], TypedStoreId]
 
-  override def max(q: Id): Either[ReadError, V] = indexedStore.max(q)
+  override def max(id: Id): MaxEither =
+    indexedStore
+      .max(id)
+      .map { case Identified(Version(_, version), typedStoreId) => (version, typedStoreId) }
+      .flatMap { case (version, typedStoreId) =>
+        typedStore
+          .get(typedStoreId)
+          .map { case Identified(_, t) => Identified(Version(id, version), t) }
+      }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/VersionedStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/VersionedStore.scala
@@ -22,7 +22,8 @@ class VersionedStore[Id, V, T](
   private def increment(v: V): V = N.plus(v, N.one)
 
   private def nextVersionFor(id: Id): Either[ReadError, V] =
-    store.max(id)
+    store
+      .max(id)
       .map { case Identified(Version(_, version), _) => increment(version) }
 
   private val matchErrors: PartialFunction[
@@ -86,11 +87,10 @@ class VersionedStore[Id, V, T](
     }
 
   def getLatest(id: Id): ReadEither =
-    store.max(id)
-      .left.map {
-        case NoMaximaValueError(_) => NoVersionExistsError()
-        case err => err
-      }
+    store.max(id).left.map {
+      case NoMaximaValueError(_) => NoVersionExistsError()
+      case err                   => err
+    }
 
   def put(id: Version[Id, V])(t: T): WriteEither =
     store.max(id.id) match {

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/VersionedStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/VersionedStore.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.storage.maxima.Maxima
 import scala.util.{Failure, Success, Try}
 
 class VersionedStore[Id, V, T](
-  val store: Store[Version[Id, V], T] with Maxima[Id, V]
+  val store: Store[Version[Id, V], T] with Maxima[Id, Version[Id, V], T]
 )(implicit N: Numeric[V], O: Ordering[V])
     extends Store[Version[Id, V], T]
     with Logging {
@@ -22,7 +22,8 @@ class VersionedStore[Id, V, T](
   private def increment(v: V): V = N.plus(v, N.one)
 
   private def nextVersionFor(id: Id): Either[ReadError, V] =
-    store.max(id).map(increment)
+    store.max(id)
+      .map { case Identified(Version(_, version), _) => increment(version) }
 
   private val matchErrors: PartialFunction[
     StorageEither,
@@ -85,22 +86,20 @@ class VersionedStore[Id, V, T](
     }
 
   def getLatest(id: Id): ReadEither =
-    store.max(id) match {
-      case Right(v) => get(Version(id, v))
-      case Left(NoMaximaValueError(_)) =>
-        Left(NoVersionExistsError())
-      case Left(err) => Left(err)
-    }
+    store.max(id)
+      .left.map {
+        case NoMaximaValueError(_) => NoVersionExistsError()
+        case err => err
+      }
 
   def put(id: Version[Id, V])(t: T): WriteEither =
     store.max(id.id) match {
-      case Right(latestV) if O.gt(latestV, id.version) =>
+      case Right(latest) if O.gt(latest.id.version, id.version) =>
         Left(HigherVersionExistsError())
-      case Right(latestV) if latestV == id.version =>
+      case Right(latest) if latest.id.version == id.version =>
         Left(VersionAlreadyExistsError())
       case _ =>
-        store
-          .put(id)(t)
+        store.put(id)(t)
     }
 
   def putLatest(id: Id)(t: T): WriteEither = {

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -24,7 +24,7 @@ class DynamoHashRangeStore[HashKey, RangeKey, T](val config: DynamoConfig)(
     with DynamoHashRangeMaxima[
       HashKey,
       RangeKey,
-      DynamoHashRangeEntry[HashKey, RangeKey, T]] {
+      T] {
 
   override protected val table =
     Table[DynamoHashRangeEntry[HashKey, RangeKey, T]](config.tableName)
@@ -40,10 +40,10 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
 ) extends Store[Version[HashKey, V], T]
     with DynamoHashReadable[HashKey, V, T]
     with DynamoHashWritable[HashKey, V, T]
-    with Maxima[HashKey, V] {
-  override def max(hashKey: HashKey): Either[ReadError, V] =
-    getEntry(hashKey).map { _.version } match {
-      case Right(value)               => Right(value)
+    with Maxima[HashKey, Version[HashKey, V], T] {
+  override def max(hashKey: HashKey): MaxEither =
+    getEntry(hashKey) match {
+      case Right(value)               => Right(Identified(Version(value.hashKey, value.version), value.payload))
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
       case Left(err)                  => Left(err)
     }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -21,10 +21,7 @@ class DynamoHashRangeStore[HashKey, RangeKey, T](val config: DynamoConfig)(
 ) extends Store[Version[HashKey, RangeKey], T]
     with DynamoHashRangeReadable[HashKey, RangeKey, T]
     with DynamoHashRangeWritable[HashKey, RangeKey, T]
-    with DynamoHashRangeMaxima[
-      HashKey,
-      RangeKey,
-      T] {
+    with DynamoHashRangeMaxima[HashKey, RangeKey, T] {
 
   override protected val table =
     Table[DynamoHashRangeEntry[HashKey, RangeKey, T]](config.tableName)
@@ -43,7 +40,8 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
     with Maxima[HashKey, Version[HashKey, V], T] {
   override def max(hashKey: HashKey): MaxEither =
     getEntry(hashKey) match {
-      case Right(value)               => Right(Identified(Version(value.hashKey, value.version), value.payload))
+      case Right(value) =>
+        Right(Identified(Version(value.hashKey, value.version), value.payload))
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
       case Left(err)                  => Left(err)
     }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.storage.streaming.Codec
 
 class MemoryHybridStoreWithMaxima[Id, T](
   implicit val typedStore: MemoryTypedStore[String, T],
-  val indexedStore: Store[Version[Id, Int], String] with Maxima[Id, Version[Id, Int], String],
+  val indexedStore: Store[Version[Id, Int], String] with Maxima[
+    Id,
+    Version[Id, Int],
+    String],
   val codec: Codec[T]
 ) extends HybridStoreWithMaxima[Id, Int, String, T] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.storage.streaming.Codec
 
 class MemoryHybridStoreWithMaxima[Id, T](
   implicit val typedStore: MemoryTypedStore[String, T],
-  val indexedStore: Store[Version[Id, Int], String] with Maxima[Id, Int],
+  val indexedStore: Store[Version[Id, Int], String] with Maxima[Id, Version[Id, Int], String],
   val codec: Codec[T]
 ) extends HybridStoreWithMaxima[Id, Int, String, T] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStore.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.VersionedStore
 
 class MemoryVersionedStore[Id, T](
-  store: MemoryStore[Version[Id, Int], T] with Maxima[Id, Int]
+  store: MemoryStore[Version[Id, Int], T] with Maxima[Id, Version[Id, Int], T]
 ) extends VersionedStore[Id, Int, T](store)
 
 object MemoryVersionedStore {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/maxima/MaximaTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/maxima/MaximaTestCases.scala
@@ -12,7 +12,7 @@ trait MaximaTestCases
     with Matchers
     with RecordGenerators
     with EitherValues {
-  type MaximaStub = Maxima[IdentityKey, Int]
+  type MaximaStub = Maxima[IdentityKey, Version[IdentityKey, Int], Record]
 
   def withMaxima[R](initialEntries: Map[Version[IdentityKey, Int], Record])(
     testWith: TestWith[MaximaStub, R]): R

--- a/storage/src/test/scala/uk/ac/wellcome/storage/maxima/MaximaTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/maxima/MaximaTestCases.scala
@@ -4,7 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.{IdentityKey, NoMaximaValueError, Version}
+import uk.ac.wellcome.storage.{Identified, IdentityKey, NoMaximaValueError, Version}
 import uk.ac.wellcome.storage.generators.{Record, RecordGenerators}
 
 trait MaximaTestCases
@@ -22,43 +22,46 @@ trait MaximaTestCases
     describe("max") {
       it("finds the maximum value with one matching entry") {
         val id = createIdentityKey
+        val r = createRecord
 
         val initialEntries = Map(
-          Version(id, 1) -> createRecord
+          Version(id, 1) -> r
         )
 
         withMaxima(initialEntries) {
-          _.max(id).value shouldBe 1
+          _.max(id).value shouldBe Identified(Version(id, 1), r)
         }
       }
 
       it("finds the maximum value with multiple matching entries") {
         val id = createIdentityKey
+        val r = createRecord
 
         val initialEntries = Map(
           Version(id, 1) -> createRecord,
           Version(id, 2) -> createRecord,
           Version(id, 3) -> createRecord,
-          Version(id, 5) -> createRecord
+          Version(id, 5) -> r
         )
 
         withMaxima(initialEntries) {
-          _.max(id).value shouldBe 5
+          _.max(id).value shouldBe Identified(Version(id, 5), r)
         }
       }
 
       it("only looks at the identifier in question") {
         val id = createIdentityKey
+        val r = createRecord
 
         val initialEntries = Map(
           Version(id, 1) -> createRecord,
           Version(id, 2) -> createRecord,
-          Version(id, 3) -> createRecord,
+          Version(id, 3) -> r,
           Version(createIdentityKey, 5) -> createRecord
         )
 
         withMaxima(initialEntries) {
-          _.max(id).value shouldBe 3
+          _.max(id).value shouldBe Identified(Version(id, 3), r)
         }
       }
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
@@ -33,7 +33,7 @@ class DynamoHashRangeMaximaTest extends MaximaTestCases with DynamoFixtures {
       implicit val formatHashKey: DynamoFormat[IdentityKey],
       implicit val formatRangeKey: DynamoFormat[Int],
       implicit val format: DynamoFormat[Entry]
-    ) extends DynamoHashRangeMaxima[IdentityKey, Int, Entry] {
+    ) extends DynamoHashRangeMaxima[IdentityKey, Int, Record] {
       val table = ScanamoTable[Entry](dynamoTable.name)
 
       val client: AmazonDynamoDB = dynamoClient

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/VersionedStoreRaceConditionsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/VersionedStoreRaceConditionsTest.scala
@@ -31,8 +31,10 @@ class VersionedStoreRaceConditionsTest
 
     // The two stores share their entries, but we want to gate the calls
     // to max() in this store.
-    private val stoppingStore = new Store[Version[String, Int], String] with Maxima[String, Int] {
-      override def max(id: String): Either[MaximaError, Int] = {
+    // TODO: Don't use string as the value in this store.
+    private val stoppingStore = new Store[Version[String, Int], String]
+        with Maxima[String, Version[String, Int], String] {
+      override def max(id: String): MaxEither = {
         debug(s"Calling max(id = $id)")
         debug(s"max: actualMaxCalls = $actualMaxCalls, allowedMaxCalls = $allowedMaxCalls")
         while (allowedMaxCalls <= actualMaxCalls) {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
@@ -73,12 +73,20 @@ class DynamoSingleVersionStoreTest
     initialEntries: Map[Version[String, Int], Record])(
     testWith: TestWith[VersionedStoreImpl, R]): R =
     withLocalDynamoDbTable { table =>
-      val store = new DynamoStoreStub(
-        config = createDynamoConfigWith(table)
-      ) {
+      val config = createDynamoConfigWith(table)
+
+      val underlying =
+        new DynamoHashStore[String, Int, Record](config) {
+          override def max(hashKey: String): MaxEither =
+            Left(StoreReadError(new Error("BOOM!")))
+        }
+
+      val store = new DynamoStoreStub(config) {
         override def get(id: Version[String, Int]): ReadEither = {
           Left(StoreReadError(new Error("BOOM!")))
         }
+
+        override val store: DynamoHashStore[String, Int, Record] = underlying
       }
 
       insertEntries(table)(initialEntries)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/VersionedStoreFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/fixtures/VersionedStoreFixtures.scala
@@ -2,11 +2,9 @@ package uk.ac.wellcome.storage.store.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.store.{Store, VersionedStore}
+import uk.ac.wellcome.storage.store.VersionedStore
 
 trait VersionedStoreFixtures[Id, V, T, VersionedStoreContext] {
-  type StoreWithMaximaImpl = Store[Version[Id, V], T] with Maxima[Id, V]
   type VersionedStoreImpl = VersionedStore[Id, V, T]
 
   type Entries = Map[Version[Id, V], T]

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
@@ -49,10 +49,11 @@ class MemoryVersionedStoreTest
     testWith: TestWith[VersionedStoreImpl, R]): R = {
     val store = new MemoryStore[Version[String, Int], Record](initialEntries)
     with MemoryMaxima[String, Record] {
-      override def get(id: Version[String, Int])
-        : Either[ReadError, Identified[Version[String, Int], Record]] = {
+      override def get(id: Version[String, Int]): ReadEither =
         Left(StoreReadError(new Error("BOOM!")))
-      }
+
+      override def max(id: String): MaxEither =
+        Left(StoreReadError(new Error("BOOM!")))
     }
     testWith(new MemoryVersionedStore(store))
   }


### PR DESCRIPTION
Previously, getLatest() was implemented in an inefficient way:

1. What’s the max version for a given ID?
2. What's the item for this given (id, version) pair?

We have to look up the whole DynamoDB item to answer question (1), so just return that rather than dropping the rest of the item to return an Int.

This doesn't change the interface to getLatest(); it just becomes more efficient. It does change the interface of Maxima (hence the major version bump), but we only use that in one place outside the libraries, and it's accompanied by a comment describing this exact change: https://github.com/wellcomecollection/storage-service/blob/72aad5d5edc6dc125d079d055643ea11dc4d94c7/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDao.scala#L79-L85

Another piece for https://github.com/wellcomecollection/platform/issues/4913. I don't have enough profiling data to say how much of a difference this will make (if any), but it's hard to imagine shedding several million DynamoDB queries won't have an impact on speed (and cost!).

This function is used plenty in the catalogue:

* It's used to look up source records in the Calm, METS and Sierra transformers
* It's used to look up records in the Items VHS in the Sierra item merger, and then again (via VersionedStore.update() to actually write the record)
* It's used to upsert records in the bib merger, item merger, and items_to_dynamo
* It's used to decide if we should replace a record in the Calm adapter

Similarly in the storage service:

* The bag and ingest trackers both use it to retrieve and update records
* The replica aggregator uses it to upsert replica records

So halving the number of Dynamo calls it makes will hopefully make a tidy dent in the pipeline performance.