### PR TITLE
Fix the return error type of Maxima.max

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The error type of Maxima.max() should be MaximaError, not ReadError.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/maxima/Maxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/maxima/Maxima.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.storage.maxima
 
-import uk.ac.wellcome.storage.{Identified, ReadError}
+import uk.ac.wellcome.storage.{Identified, MaximaError}
 
 trait Maxima[QueryParameter, Id, T] {
-  type MaxEither = Either[ReadError, Identified[Id, T]]
+  type MaxEither = Either[MaximaError, Identified[Id, T]]
 
   def max(q: QueryParameter): MaxEither
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.storage.store
 
-import uk.ac.wellcome.storage.{Identified, Version}
+import uk.ac.wellcome.storage.{DoesNotExistError, Identified, MaximaReadError, NoMaximaValueError, ReadError, Version}
 import uk.ac.wellcome.storage.maxima.Maxima
 
 trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
@@ -16,10 +16,10 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
       .max(id)
       .flatMap {
         case Identified(Version(_, version), typedStoreId) =>
-          typedStore
-            .get(typedStoreId)
-            .map {
-              case Identified(_, t) => Identified(Version(id, version), t)
-            }
+          typedStore.get(typedStoreId) match {
+            case Right(Identified(_, t)) => Right(Identified(Version(id, version), t))
+            case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
+            case Left(err: ReadError) => Left(MaximaReadError(err.e))
+          }
       }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStoreWithMaxima.scala
@@ -1,6 +1,13 @@
 package uk.ac.wellcome.storage.store
 
-import uk.ac.wellcome.storage.{DoesNotExistError, Identified, MaximaReadError, NoMaximaValueError, ReadError, Version}
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  Identified,
+  MaximaReadError,
+  NoMaximaValueError,
+  ReadError,
+  Version
+}
 import uk.ac.wellcome.storage.maxima.Maxima
 
 trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
@@ -17,9 +24,10 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
       .flatMap {
         case Identified(Version(_, version), typedStoreId) =>
           typedStore.get(typedStoreId) match {
-            case Right(Identified(_, t)) => Right(Identified(Version(id, version), t))
+            case Right(Identified(_, t)) =>
+              Right(Identified(Version(id, version), t))
             case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
-            case Left(err: ReadError) => Left(MaximaReadError(err.e))
+            case Left(err: ReadError)       => Left(MaximaReadError(err.e))
           }
       }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -43,7 +43,7 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
       case Right(value) =>
         Right(Identified(Version(value.hashKey, value.version), value.payload))
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
-      case Left(err: ReadError) => Left(MaximaReadError(err.e))
+      case Left(err: ReadError)       => Left(MaximaReadError(err.e))
     }
 
   override protected val table =

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -43,7 +43,7 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
       case Right(value) =>
         Right(Identified(Version(value.hashKey, value.version), value.payload))
       case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
-      case Left(err)                  => Left(err)
+      case Left(err: ReadError) => Left(MaximaReadError(err.e))
     }
 
   override protected val table =

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult
 import org.scanamo.auto._
 import org.scanamo.{Table => ScanamoTable}
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
 import uk.ac.wellcome.storage.dynamo.DynamoHashRangeEntry
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
@@ -78,7 +78,7 @@ class DynamoMultipleVersionStoreTest
       val underlying =
         new DynamoHashRangeStore[String, Int, Record](config) {
           override def max(hashKey: String): MaxEither =
-            Left(StoreReadError(new Error("BOOM!")))
+            Left(MaximaReadError(new Error("BOOM!")))
         }
 
       val store = new DynamoStoreStub(config) {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.generators.{Record, RecordGenerators}
 import uk.ac.wellcome.storage.store._
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
 import org.scanamo.auto._
 
 class DynamoSingleVersionStoreTest
@@ -78,7 +78,7 @@ class DynamoSingleVersionStoreTest
       val underlying =
         new DynamoHashStore[String, Int, Record](config) {
           override def max(hashKey: String): MaxEither =
-            Left(StoreReadError(new Error("BOOM!")))
+            Left(MaximaReadError(new Error("BOOM!")))
         }
 
       val store = new DynamoStoreStub(config) {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.generators.{Record, RecordGenerators}
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.VersionedStoreWithOverwriteTestCases
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
 
 class DynamoVersionedHybridStoreTest
     extends VersionedStoreWithOverwriteTestCases[
@@ -35,7 +35,7 @@ class DynamoVersionedHybridStoreTest
             Int,
             Record](prefix)(indexedStore, typedStore) {
             override def max(id: String): MaxEither =
-              Left(StoreReadError(new Error("BOOM!")))
+              Left(MaximaReadError(new Error("BOOM!")))
           }
 
         initialEntries.map {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.storage.store.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
+import uk.ac.wellcome.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
 import uk.ac.wellcome.storage.generators.{Record, RecordGenerators}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.VersionedStoreWithOverwriteTestCases
@@ -24,7 +24,7 @@ class MemoryVersionedHybridStoreTest
 
     val store = new MemoryHybridStoreWithMaxima[String, Record]() {
       override def max(id: String): MaxEither =
-        Left(StoreReadError(new Error("BOOM!")))
+        Left(MaximaReadError(new Error("BOOM!")))
     }
 
     initialEntries.map {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedStoreTest.scala
@@ -53,7 +53,7 @@ class MemoryVersionedStoreTest
         Left(StoreReadError(new Error("BOOM!")))
 
       override def max(id: String): MaxEither =
-        Left(StoreReadError(new Error("BOOM!")))
+        Left(MaximaReadError(new Error("BOOM!")))
     }
     testWith(new MemoryVersionedStore(store))
   }


### PR DESCRIPTION
Oops. 🙈 

I changed this return type in my previous PR.

This blocks using the newest version in the storage-service repo.