### PR TITLE
Treat a NativeIoException when reading a blob from Azure as retryable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Treat a `NativeIoException` when reading a blob from Azure as retryable.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureStorageErrors.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/azure/AzureStorageErrors.scala
@@ -12,11 +12,28 @@ object AzureStorageErrors {
   val readErrors: PartialFunction[Throwable, ReadError] = {
     case exc: BlobStorageException if exc.getStatusCode == 404 =>
       DoesNotExistError(exc)
+
     case exc if exc.getMessage.contains("TimeoutException") =>
-      // Timeout errors from Azure should be retried and are in the form
-      // "reactor.core.Exceptions$ReactiveException: java.util.concurrent.TimeoutException: Did not
-      // observe any item or terminal signal within 60000ms in 'map' (and no fallback has been configured)"
+      // Timeout errors from Azure should be retried and are of the form
+      //
+      //    reactor.core.Exceptions$ReactiveException: java.util.concurrent.TimeoutException:
+      //    Did not observe any item or terminal signal within 60000ms in 'map'
+      //    (and no fallback has been configured)
+      //
+      // Note: we cannot make assertions on the type ReactiveException; for
+      // some reason it's a type we can't import it for isInstanceOf[…].
       new StoreReadError(exc) with RetryableError
+
+    case exc if exc.getMessage.contains("NativeIoException") =>
+      // IO errors from Azure should be retried and are of the form
+      //
+      //    reactor.core.Exceptions$ReactiveException: io.netty.channel.unix.Errors$NativeIoException:
+      //    readAddress(..) failed: Connection reset by peer
+      //
+      // Note: we cannot make assertions on the type ReactiveException; for
+      // some reason it's a type we can't import it for isInstanceOf[…].
+      new StoreReadError(exc) with RetryableError
+
     case exc =>
       StoreReadError(exc)
   }


### PR DESCRIPTION
I suspect this will fix the few flaky Azure errors we've seen recently.

h/t to @alicefuzier who did the original work to investigate these `ReactiveException` errors, and left a really obvious way to extend it. I forget the details, but something in how Azure handles exceptions makes this non-trivial. Not for me though! :D