### PR TITLE
Use BatchWriteItem to reduce cost + network traffic from Dynamo unlocks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release changes DynamoLockDao to use BatchWriteItem to release locks.  This will have no impact on callers, but should make unlocking faster and cheaper if you lock multiple IDs.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDao.scala
@@ -5,7 +5,10 @@ import java.util.UUID
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, PutItemResult}
+import com.amazonaws.services.dynamodbv2.model.{
+  BatchWriteItemResult,
+  PutItemResult
+}
 import grizzled.slf4j.Logging
 import org.scanamo.query.Condition
 import org.scanamo.semiauto._
@@ -96,7 +99,8 @@ class DynamoLockDao(
       _ <- deleteLocks(rowLocks)
     } yield ()
 
-  private def deleteLocks(rowLocks: List[ExpiringLock]): Either[Throwable, Unit] =
+  private def deleteLocks(
+    rowLocks: List[ExpiringLock]): Either[Throwable, Unit] =
     Try {
       val ids = rowLocks.map { _.id }.toSet
       val ops = table.deleteAll('id -> ids)
@@ -109,7 +113,9 @@ class DynamoLockDao(
           throw new Throwable(s"Unable to unlock all locks in batch $rowLocks")
         }
       }
-    }.map { _ => () }.toEither
+    }.map { _ =>
+      ()
+    }.toEither
 
   private def queryLocks(contextId: ContextId) = Try {
     val queryT = EitherT(

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/dynamo/DynamoLockDaoTest.scala
@@ -103,6 +103,21 @@ class DynamoLockDaoTest
       }
     }
 
+    it("can lock > 25 locks") {
+      // 25 is more than the BatchSize supported for a single BatchWriteItem
+      // operation in DynamoDB.
+      withLocalDynamoDbTable { lockTable =>
+        withLockDao(lockTable, seconds = 1) { lockDao =>
+          (1 to 50).map { id =>
+            lockDao.lock(id.toString, staticContextId).value
+          }
+
+          lockDao.unlock(staticContextId)
+          assertNoLocks(lockTable)
+        }
+      }
+    }
+
     describe("Locking problems") {
       it("fails if there is a problem writing the lock") {
         val mockClient = mock[AmazonDynamoDB]


### PR DESCRIPTION
See also: https://github.com/wellcomecollection/catalogue/pull/1262, https://github.com/wellcomecollection/platform/issues/4969