### PR TITLE
Don't acquire known-unusable locks in LockingService

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch makes the locking service slightly more efficient in scenarios where multiple processes are trying to acquire overlapping sets of locks.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/locking/LockingService.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/locking/LockingService.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.data._
 import grizzled.slf4j.Logging
 
+import scala.annotation.tailrec
 import scala.language.higherKinds
 
 trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
@@ -60,58 +61,31 @@ trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
     * unlock the entire context and report a failure.
     *
     */
+  @tailrec
   private def getLocks(ids: Set[lockDao.Ident],
-                       contextId: lockDao.ContextId): LockingServiceResult = {
-
+                       contextId: lockDao.ContextId): LockingServiceResult =
     // We lock the IDs one-by-one, but if any ID fails to lock, we skip
     // even trying to lock the remaining IDs.
     //
     // This reduces the amount of churn in the LockDao: we're skipping creating
     // and deleting a lock we know will never be used.
-    val lockResults =
-      ids.foldLeft(Set[lockDao.LockResult]())(
-        (existingResults: Set[lockDao.LockResult], id) => {
-          val failedIds = getFailedLocks(existingResults).map { _.id }
-
-          if (failedIds.isEmpty) {
-            existingResults ++ Set(lockDao.lock(id, contextId))
-          } else {
-            existingResults ++ Set(
-              Left(
-                LockFailure(
-                  id,
-                  e = new Throwable(
-                    s"Skipping locking $id; other IDs have already failed to lock"
-                  ))
-              )
-            )
-          }
-        }
-      )
-
-    assert(
-      lockResults.size == ids.size,
-      s"Got the wrong number of lockResults: size($lockResults) != size($ids)"
-    )
-
-    val failedLocks = getFailedLocks(lockResults)
-
-    if (failedLocks.isEmpty) {
+    if (ids.isEmpty) {
       Right(contextId)
     } else {
-      unlock(contextId)
-      Left(FailedLock(contextId, failedLocks))
-    }
-  }
-
-  private def getFailedLocks(
-    lockResults: Set[lockDao.LockResult]): Set[LockFailure[lockDao.Ident]] =
-    lockResults.foldLeft(Set.empty[LockFailure[lockDao.Ident]]) { (acc, o) =>
-      o match {
-        case Right(_)         => acc
-        case Left(failedLock) => acc + failedLock
+      lockDao.lock(ids.head, contextId) match {
+        case Left(failure) =>
+          Left(FailedLock(contextId, ids.tail.map(skipped) + failure))
+        case Right(_) => getLocks(ids.tail, contextId)
       }
     }
+
+  private def skipped[Ident](id: Ident): LockFailure[Ident] =
+    LockFailure(
+      id,
+      e = new Throwable(
+        s"Skipping locking $id; other IDs have already failed to lock"
+      )
+    )
 
   private def unlock(contextId: lockDao.ContextId): Unit =
     lockDao

--- a/storage/src/main/scala/uk/ac/wellcome/storage/locking/LockingService.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/locking/LockingService.scala
@@ -78,9 +78,11 @@ trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
           } else {
             existingResults ++ Set(
               Left(
-                LockFailure(id, e = new Throwable(
-                  s"Skipping locking $id; other IDs have already failed to lock"
-                ))
+                LockFailure(
+                  id,
+                  e = new Throwable(
+                    s"Skipping locking $id; other IDs have already failed to lock"
+                  ))
               )
             )
           }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/LockingServiceFixtures.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/LockingServiceFixtures.scala
@@ -47,14 +47,13 @@ trait LockingServiceFixtures[Ident, ContextId, LockDaoContext]
     successfulRightOf(result) shouldBe expectedResult
   }
 
-  def assertFailedLock(result: ResultF, lockIds: Set[Ident]): Assertion = {
+  def assertFailedLock(result: ResultF, lockIds: Set[Ident], expectedFailures: Set[Ident]): Assertion = {
     debug(s"Got $result, with $lockIds")
     val failedLock = successfulLeftOf(result)
       .asInstanceOf[FailedLock[ContextId, Ident]]
 
     failedLock.lockFailures shouldBe a[Set[_]]
-    failedLock.lockFailures
-      .map { _.id } should contain theSameElementsAs lockIds
+    failedLock.lockFailures.map { _.id } shouldBe expectedFailures
   }
 
   def assertFailedProcess(result: ResultF, e: Throwable): Assertion = {

--- a/storage/src/test/scala/uk/ac/wellcome/storage/locking/LockingServiceTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/locking/LockingServiceTestCases.scala
@@ -67,7 +67,11 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
         withLockDao(lockDaoContext) { lockDao =>
           withLockingService(lockDao) { service =>
             assertLockSuccess(service.withLocks(lockIds) {
-              assertFailedLock(service.withLocks(lockIds)(f), lockIds)
+              assertFailedLock(
+                result = service.withLocks(lockIds)(f),
+                lockIds = lockIds,
+                expectedFailures = lockIds
+              )
 
               // Check the original locks were preserved
               getCurrentLocks(lockDao, lockDaoContext) shouldBe lockIds
@@ -85,8 +89,10 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
           withLockingService(lockDao) { service =>
             assertLockSuccess(service.withLocks(lockIds) {
               assertFailedLock(
-                service.withLocks(overlappingLockIds)(f),
-                commonLockIds)
+                result = service.withLocks(overlappingLockIds)(f),
+                lockIds = commonLockIds,
+                expectedFailures = overlappingLockIds
+              )
 
               // Check the original locks were preserved
               getCurrentLocks(lockDao, lockDaoContext) shouldBe lockIds
@@ -127,8 +133,9 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
         assertLockSuccess(service.withLocks(lockIds) {
 
           assertFailedLock(
-            service.withLocks(overlappingLockIds)(f),
-            commonLockIds
+            result = service.withLocks(overlappingLockIds)(f),
+            lockIds = commonLockIds,
+            expectedFailures = overlappingLockIds
           )
 
           assertLockSuccess(


### PR DESCRIPTION
The DynamoDB lock table is now one of the main costs of a reindex in the catalogue pipeline, so I've been looking for ways to make it more efficient.  We do see locking failures in the matcher logs, so some processes are trying to acquire the same/similar locks.

Previously, the locking service would lock IDs in sequence, e.g.:

    lockDao.lock(id1)
    lockDao.lock(id2)
    lockDao.lock(id3)

But if we get a failure on locking `id1`, trying to lock `id2` and `id3` is pointless.  We create and then delete two locks that we know we can never use, which is expensive and potentially stops another process from locking one of those IDs.

Now, if the locking service detects a failure to lock `id1`, it skips locking `id2` and `id3`, and goes straight to the cleanup stage.

I don't know how much of a difference this will make -- I'd bet a few percentage points at best -- because this code is already fairly heavily optimised, but having spotted this simple optimisation I figured it couldn't hurt to add.