### PR TITLE
Add ability to run an arbitrary graph between a provided sink and source in SQSStream

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds the option to pass to SQSStream a function that creates an entire RunnableGraph from a source and sink.

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -63,7 +63,7 @@ class SQSStream[T](
   )(implicit decoder: Decoder[T]): Future[Done] = {
     val metricName = s"${streamName}_ProcessMessage"
 
-    val decodedSupervisedSource = source
+    val decodedSource = source
       .map { message =>
         (message, fromJson[T](message.body).get)
       }
@@ -76,7 +76,7 @@ class SQSStream[T](
       }
       .toMat(sink)(Keep.right)
 
-    graphBetween(decodedSupervisedSource, loggingSink)
+    graphBetween(decodedSource, loggingSink)
       .withAttributes(ActorAttributes.supervisionStrategy(decider(metricName)))
       .run()
       .map { _ =>

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -2,9 +2,8 @@ package uk.ac.wellcome.messaging.sqs
 
 import akka.actor.ActorSystem
 import akka.stream.alpakka.sqs.MessageAction
-import akka.stream.alpakka.sqs.MessageAction.Delete
 import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
-import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source}
 import akka.stream.{ActorAttributes, Supervision}
 import akka.{Done, NotUsed}
 import grizzled.slf4j.Logging
@@ -58,25 +57,26 @@ class SQSStream[T](
         }
     )
 
-  def runStream(
-    streamName: String,
-    modifySource: Source[(Message, T), NotUsed] => Source[Message, NotUsed])(
-    implicit decoder: Decoder[T]): Future[Done] = {
+  def runGraph(streamName: String)(
+    graphBetween: (Source[(Message, T), NotUsed],
+                   Sink[Message, Future[Done]]) => RunnableGraph[Future[Done]]
+  )(implicit decoder: Decoder[T]): Future[Done] = {
     val metricName = s"${streamName}_ProcessMessage"
 
-    val src = modifySource(source.map { message =>
-      (message, fromJson[T](message.body).get)
-    })
+    val decodedSupervisedSource = source
+      .map { message =>
+        (message, fromJson[T](message.body).get)
+      }
 
-    val srcWithLogging: Source[Delete, NotUsed] = src
+    val loggingSink = Flow[Message]
       .map { m =>
         metricsSender.incrementCount(s"${metricName}_success")
         debug(s"Deleting message ${m.messageId()}")
-        (MessageAction.Delete(m))
+        MessageAction.Delete(m)
       }
-
-    srcWithLogging
       .toMat(sink)(Keep.right)
+
+    graphBetween(decodedSupervisedSource, loggingSink)
       .withAttributes(ActorAttributes.supervisionStrategy(decider(metricName)))
       .run()
       .map { _ =>
@@ -89,6 +89,14 @@ class SQSStream[T](
           Done
       }
   }
+
+  def runStream(
+    streamName: String,
+    modifySource: Source[(Message, T), NotUsed] => Source[Message, NotUsed])(
+    implicit decoder: Decoder[T]): Future[Done] =
+    runGraph(streamName) { (source, sink) =>
+      modifySource(source).toMat(sink)(Keep.right)
+    }
 
   // Defines a "supervision strategy" -- this tells Akka how to react
   // if one of the elements fails.  We want to log the failing message,


### PR DESCRIPTION
I've wanted this for ages as having to propagate messages all the way through `runStream` can be a pain - thought I'd finally implement it.

Currently, `SQSStream` offers us
- `foreach` to apply a basic transformation function returning a `Future`
- `runStream` to modify a given `Source`, which is useful for applying transformations using akka-streams

Any linear graph that goes from a `Source` to a `Sink` via any combination of `Flow`s or whatever is strictly equivalent to a single `Source` -> `Sink`: that's why `runStream` works well for most use cases, even though our only input is a mutator of a `Source`.

However, we might want a non-linear graph: for example, there might be a "fork" where we want to complete some messages early as they require further processing. With `runStream` those messages would still have to be propagated all the way so that they can be sunk into an SQS ack at the end. 

This can sometimes be worked around by merging `Flow`s with `flatMapConcat` etc, but I think that it's cases like this where akka-streams can seem needlessly complex - because we don't have access to all of its features. This PR implements `runGraph` which gives us a `Source` of messages and a `Sink` to ack them, and leaves it up to us to put whatever graph we want between them.