### PR TITLE
Add randomSample to RandomGenerators

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Adds a method to RandomGenerators for taking a random sample from a given Seq

--- a/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
@@ -52,15 +52,18 @@ trait RandomGenerators {
 
   // The slightly unusual default means IntelliJ won't whinge that min=0 is
   // the default when you use it.
-  def collectionOf[T](
-    min: Int = chooseFrom(0),
-    max: Int = 10)(f: => T): Seq[T] =
+  def collectionOf[T](min: Int = chooseFrom(0), max: Int = 10)(
+    f: => T): Seq[T] =
     (1 to randomInt(from = min, to = max)).map { _ =>
       f
     }
 
   def chooseFrom[T](seq: T*): T =
     seq(Random.nextInt(seq.size))
+
+  def randomSample[T](seq: Seq[T])(
+    size: Int = randomInt(from = 1, to = seq.size)
+  ): Seq[T] = Random.shuffle(seq).take(size)
 
   def randomInstant: Instant =
     Instant.now().plusSeconds(Random.nextInt())

--- a/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/uk/ac/wellcome/fixtures/RandomGenerators.scala
@@ -61,9 +61,8 @@ trait RandomGenerators {
   def chooseFrom[T](seq: T*): T =
     seq(Random.nextInt(seq.size))
 
-  def randomSample[T](seq: Seq[T])(
-    size: Int = randomInt(from = 1, to = seq.size)
-  ): Seq[T] = Random.shuffle(seq).take(size)
+  def randomSample[T](seq: Seq[T], size: Int): Seq[T] =
+    Random.shuffle(seq).take(size)
 
   def randomInstant: Instant =
     Instant.now().plusSeconds(Random.nextInt())


### PR DESCRIPTION
This is a useful thing to have for taking members from an existing sequence:

```scala
val things = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
val randomThings = randomSample(things, size = 3) // e.g. Seq(7, 2, 9); 3 random elements of `things`
```