### PR TITLE
Delete SQS messages in batches of 10, not individually

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+SQSStream and AlpakkaSQSWorker are now using DeleteMessageBatch rather than DeleteMessage.
+This should have no user-visible effects.

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -42,7 +42,7 @@ class SQSStream[T](
   private val source: Source[Message, NotUsed] =
     SqsSource(sqsConfig.queueUrl)(sqsClient)
   private val sink: Sink[MessageAction, Future[Done]] =
-    SqsAckSink(sqsConfig.queueUrl)(sqsClient)
+    SqsAckSink.grouped(sqsConfig.queueUrl)(sqsClient)
 
   def foreach(streamName: String, process: T => Future[Unit])(
     implicit decoderT: Decoder[T]): Future[Done] =

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -47,7 +47,7 @@ class AlpakkaSQSWorker[Work,
 
   val parallelism: Int = config.sqsConfig.parallelism
   val source = SqsSource(config.sqsConfig.queueUrl)
-  val sink = SqsAckSink(config.sqsConfig.queueUrl)
+  val sink = SqsAckSink.grouped(config.sqsConfig.queueUrl)
 
   val retryAction: SQSAction = (message: SQSMessage) =>
     MessageAction

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -34,7 +34,7 @@ class SQSStreamTest
   }
 
   it("reads messages off a queue, processes them and deletes them") {
-    val messages = createNamedObjects(start = 1, count = 20)
+    val messages = createNamedObjects(count = 15)
 
     withSQSStreamFixtures {
       case (messageStream, QueuePair(queue, dlq), _) =>

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -34,9 +34,11 @@ class SQSStreamTest
   }
 
   it("reads messages off a queue, processes them and deletes them") {
+    val messages = createNamedObjects(start = 1, count = 20)
+
     withSQSStreamFixtures {
       case (messageStream, QueuePair(queue, dlq), _) =>
-        sendNamedObjects(queue = queue, count = 3)
+        messages.foreach { sendSqsMessage(queue, _) }
 
         val received = new ConcurrentLinkedQueue[NamedObject]()
         val streamName = randomAlphanumeric(10)
@@ -45,14 +47,12 @@ class SQSStreamTest
           process = process(received))
 
         eventually {
-          received should contain theSameElementsAs createNamedObjects(
-            count = 3)
+          received should contain theSameElementsAs messages
 
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
     }
-
   }
 
   it("increments *_ProcessMessage metric when successful") {

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -59,7 +59,7 @@ class AlpakkaSQSWorkerTest
     }
 
     it("processes lots of messages") {
-      val works = (1 to 20).map { i => MyWork(s"my-work-$i") }
+      val works = (1 to 15).map { i => MyWork(s"my-work-$i") }
 
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>


### PR DESCRIPTION
A quick glance at Cost Explorer revealed that we spend ~$100/mo just deleting messages. Literally just to tell SQS “yeah, we did that thing, you can forget about it now”.

🤯 

AWS have an easy fix for this – rather than deleting messages individually, you [use the DeleteMessageBatch action](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-batch-api-actions.html). This turns out to be a one-line change in the constructor we use for our Alpakka SQS sink, so I've just gone ahead and done it.

I don't expect it to make a big difference, but it won't be nothing either.