### PR TITLE
Use Docker images from ECR in the scala-libs tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: format
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -14,7 +14,7 @@ steps:
   - label: test fixtures
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -23,7 +23,7 @@ steps:
   - label: test json
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -32,7 +32,7 @@ steps:
   - label: test typesafe_app
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -41,7 +41,7 @@ steps:
   - label: test messaging
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -50,7 +50,7 @@ steps:
   - label: test messaging_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -59,7 +59,7 @@ steps:
   - label: test storage
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -68,7 +68,7 @@ steps:
   - label: test storage_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -77,7 +77,7 @@ steps:
   - label: test elasticsearch
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -86,7 +86,7 @@ steps:
   - label: test elasticsearch_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -97,7 +97,7 @@ steps:
     if: build.branch == "master"
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -112,7 +112,7 @@ steps:
       PROJECT: fixtures
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -126,7 +126,7 @@ steps:
       PROJECT: json
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -140,7 +140,7 @@ steps:
       PROJECT: typesafe_app
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -154,7 +154,7 @@ steps:
       PROJECT: messaging
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -168,7 +168,7 @@ steps:
       PROJECT: messaging_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -182,7 +182,7 @@ steps:
       PROJECT: monitoring
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -196,7 +196,7 @@ steps:
       PROJECT: monitoring_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -210,7 +210,7 @@ steps:
       PROJECT: storage
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -224,7 +224,7 @@ steps:
       PROJECT: storage_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -238,7 +238,7 @@ steps:
       PROJECT: elasticsearch
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"
@@ -252,7 +252,7 @@ steps:
       PROJECT: elasticsearch_typesafe
     plugins:
       - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
           mount-ssh-agent: true
           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
           network: "host"


### PR DESCRIPTION
To avoid hitting rate limits from Docker Hub.