### PR TITLE
Don't require an ExecutionContext value here

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Don't require an ExecutionContext implicit in HttpFixtures.

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -7,16 +7,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.http.fixtures.HttpFixtures
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class WellcomeHttpAppFeatureTest
   extends AnyFunSpec
     with Matchers
     with HttpFixtures
     with IntegrationPatience {
-
-  override implicit val ec: ExecutionContext = global
 
   import weco.http.fixtures.ExampleApp._
 

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -21,16 +21,14 @@ import weco.http.WellcomeHttpApp
 import weco.http.fixtures.ExampleApp.context
 import weco.http.models.HTTPServerConfig
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait HttpFixtures extends Akka with ScalaFutures with Matchers
   with JsonAssertions{
 
-  implicit val ec: ExecutionContext
-
   private def whenRequestReady[R](
-                                   r: HttpRequest
-                                 )(testWith: TestWith[HttpResponse, R]): R =
+    r: HttpRequest
+  )(testWith: TestWith[HttpResponse, R]): R =
     withActorSystem { implicit actorSystem =>
       val request = Http().singleRequest(r)
       whenReady(request) { response: HttpResponse =>


### PR DESCRIPTION
Everywhere else we use the global EC, and it avoids resolution headaches elsewhere if we're consistent.