### PR TITLE
More flexible withApp

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,1 @@
+RELEASE_TYPE: patch


### PR DESCRIPTION
Some consumers (specifically the storage-service) require an actorSystem / metrics to be passed into WellcomeHttpApp to allow metric fakes. This change enables that.

For https://github.com/wellcomecollection/platform/issues/5162