### PR TITLE
Standardise how we define context URLs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-Don't require an ExecutionContext implicit in HttpFixtures.
+This standardises the use of context URLs with a new trait:
+
+```scala
+trait HasContextUrl {
+  def contextUrl: URL
+}
+```

--- a/http/src/main/scala/weco/http/ErrorDirectives.scala
+++ b/http/src/main/scala/weco/http/ErrorDirectives.scala
@@ -34,7 +34,7 @@ trait ErrorDirectives
 
   private def error(err: DisplayError): Route =
     complete(
-      err.httpStatus -> ContextResponse(context = contextUrl, result = err)
+      err.httpStatus -> ContextResponse(contextUrl = contextUrl, result = err)
     )
 
   def internalError(err: Throwable): Route = {

--- a/http/src/main/scala/weco/http/ErrorDirectives.scala
+++ b/http/src/main/scala/weco/http/ErrorDirectives.scala
@@ -11,10 +11,9 @@ trait ErrorDirectives
     extends Directives
     with ErrorAccumulatingCirceSupport
     with Logging
-    with DisplayJsonUtil {
+    with DisplayJsonUtil
+    with HasContextUrl {
   import weco.http.models.ContextResponse._
-
-  def context: String
 
   def gone(description: String): Route =
     error(
@@ -35,7 +34,7 @@ trait ErrorDirectives
 
   private def error(err: DisplayError): Route =
     complete(
-      err.httpStatus -> ContextResponse(context = context, result = err)
+      err.httpStatus -> ContextResponse(context = contextUrl, result = err)
     )
 
   def internalError(err: Throwable): Route = {

--- a/http/src/main/scala/weco/http/HasContextUrl.scala
+++ b/http/src/main/scala/weco/http/HasContextUrl.scala
@@ -1,0 +1,7 @@
+package weco.http
+
+import java.net.URL
+
+trait HasContextUrl {
+  def contextUrl: URL
+}

--- a/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
@@ -21,7 +21,7 @@ trait WellcomeExceptionHandler extends Logging with HasContextUrl {
         logger.error(s"Unexpected exception $err")
 
         val error = ContextResponse(
-          context = contextUrl,
+          contextUrl = contextUrl,
           DisplayError(statusCode = InternalServerError)
         )
 

--- a/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
@@ -1,20 +1,17 @@
 package weco.http
 
-import java.net.URL
-
 import akka.http.scaladsl.model.StatusCodes.InternalServerError
 import akka.http.scaladsl.server.ExceptionHandler
 import grizzled.slf4j.Logging
 import weco.http.models.{ContextResponse, DisplayError}
 import weco.http.monitoring.HttpMetrics
 
-trait WellcomeExceptionHandler extends Logging {
+trait WellcomeExceptionHandler extends Logging with HasContextUrl {
   import akka.http.scaladsl.server.Directives._
   import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
   import uk.ac.wellcome.json.JsonUtil._
 
   val httpMetrics: HttpMetrics
-  val contextURL: URL
 
   implicit val exceptionHandler: ExceptionHandler = buildExceptionHandler()
 
@@ -24,7 +21,7 @@ trait WellcomeExceptionHandler extends Logging {
         logger.error(s"Unexpected exception $err")
 
         val error = ContextResponse(
-          context = contextURL,
+          context = contextUrl,
           DisplayError(statusCode = InternalServerError)
         )
 

--- a/http/src/main/scala/weco/http/WellcomeHttpApp.scala
+++ b/http/src/main/scala/weco/http/WellcomeHttpApp.scala
@@ -19,7 +19,7 @@ class WellcomeHttpApp(
   routes: Route,
   httpServerConfig: HTTPServerConfig,
   val httpMetrics: HttpMetrics,
-  val contextURL: URL,
+  val contextUrl: URL,
   val appName: String
 )(
   implicit

--- a/http/src/main/scala/weco/http/WellcomeRejectionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeRejectionHandler.scala
@@ -1,7 +1,5 @@
 package weco.http
 
-import java.net.URL
-
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.model._
@@ -18,12 +16,11 @@ import weco.http.monitoring.HttpMetrics
 
 import scala.concurrent.ExecutionContext
 
-trait WellcomeRejectionHandler {
+trait WellcomeRejectionHandler extends HasContextUrl {
   import akka.http.scaladsl.server.Directives._
   import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
   val httpMetrics: HttpMetrics
-  val contextURL: URL
 
   implicit val ec: ExecutionContext
   implicit val rejectionHandler: RejectionHandler = buildRejectionHandler()
@@ -79,7 +76,7 @@ trait WellcomeRejectionHandler {
 
     complete(
       BadRequest -> ContextResponse(
-        context = contextURL,
+        context = contextUrl,
         DisplayError(
           statusCode = BadRequest,
           description = message.toList.mkString("\n")
@@ -98,13 +95,13 @@ trait WellcomeRejectionHandler {
         val description = data.utf8String
         if (statusCode.intValue() >= 500) {
           val response = ContextResponse(
-            context = contextURL,
+            context = contextUrl,
             DisplayError(statusCode = statusCode)
           )
           Marshal(response).to[MessageEntity]
         } else {
           val response = ContextResponse(
-            context = contextURL,
+            context = contextUrl,
             DisplayError(
               statusCode = statusCode,
               description = description

--- a/http/src/main/scala/weco/http/WellcomeRejectionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeRejectionHandler.scala
@@ -76,7 +76,7 @@ trait WellcomeRejectionHandler extends HasContextUrl {
 
     complete(
       BadRequest -> ContextResponse(
-        context = contextUrl,
+        contextUrl = contextUrl,
         DisplayError(
           statusCode = BadRequest,
           description = message.toList.mkString("\n")
@@ -95,13 +95,13 @@ trait WellcomeRejectionHandler extends HasContextUrl {
         val description = data.utf8String
         if (statusCode.intValue() >= 500) {
           val response = ContextResponse(
-            context = contextUrl,
+            contextUrl = contextUrl,
             DisplayError(statusCode = statusCode)
           )
           Marshal(response).to[MessageEntity]
         } else {
           val response = ContextResponse(
-            context = contextUrl,
+            contextUrl = contextUrl,
             DisplayError(
               statusCode = statusCode,
               description = description

--- a/http/src/main/scala/weco/http/models/ContextResponse.scala
+++ b/http/src/main/scala/weco/http/models/ContextResponse.scala
@@ -14,8 +14,8 @@ case class ContextResponse[T: Encoder](
 
 case object ContextResponse {
 
-  def apply[T: Encoder](context: URL, result: T): ContextResponse[T] =
-    ContextResponse(context = context.toString, result = result)
+  def apply[T: Encoder](contextUrl: URL, result: T): ContextResponse[T] =
+    ContextResponse(context = contextUrl.toString, result = result)
 
   // Flattens the 'result' field into the rest of the object
   implicit def encoder[T: Encoder]: Encoder[ContextResponse[T]] =

--- a/http/src/test/scala/weco/http/fixtures/ExampleApp.scala
+++ b/http/src/test/scala/weco/http/fixtures/ExampleApp.scala
@@ -4,12 +4,12 @@ import akka.http.scaladsl.model.StatusCodes.Accepted
 import akka.http.scaladsl.server.Route
 import weco.http.FutureDirectives
 
+import java.net.URL
 import scala.concurrent.Future
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object ExampleApp {
-  val context = "http://api.wellcomecollection.org/example/v1/context.json"
+  val contextUrl = new URL("http://api.wellcomecollection.org/example/v1/context.json")
 
   case class ExampleResource(name: String)
 
@@ -32,15 +32,14 @@ object ExampleApp {
         }
       }
     )
+
+    override def contextUrl: URL = ExampleApp.contextUrl
   }
 
   val exampleApi = new ExampleApi {
-
     override def getTransform(): ExampleResource = ExampleResource("hello world")
 
     override def postTransform(exampleResource: ExampleResource): String = "ok"
-
-    override def context: String = ExampleApp.context
   }
 
   val brokenGetExampleApi = new ExampleApi {
@@ -48,7 +47,5 @@ object ExampleApp {
 
     override def postTransform(exampleResource: ExampleResource): String =
       throw new Exception("BOOM!!!")
-
-    override def context: String = ExampleApp.context
   }
 }

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -1,7 +1,5 @@
 package weco.http.fixtures
 
-import java.net.URL
-
 import akka.actor.ActorSystem
 import org.scalatest.Assertion
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
@@ -19,7 +17,6 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil.toJson
 import uk.ac.wellcome.json.utils.JsonAssertions
 import weco.http.WellcomeHttpApp
-import weco.http.fixtures.ExampleApp.context
 import weco.http.models.HTTPServerConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -138,7 +135,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         jsonResponse,
         s"""
            |{
-           |  "@context": "$context",
+           |  "@context": "${ExampleApp.contextUrl}",
            |  "errorType": "http",
            |  "httpStatus": ${statusCode.intValue()},
            |  "label": "${statusCode.reason()}",
@@ -163,7 +160,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         routes = routes,
         httpMetrics = httpMetrics.getOrElse(defaultHttpMetrics),
         httpServerConfig = httpServerConfigTest,
-        contextURL = new URL(context),
+        contextUrl = ExampleApp.contextUrl,
         appName = metricsName
       )(actorSystem.getOrElse(defaultActorSystem), ec)
 

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -162,7 +162,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         httpServerConfig = httpServerConfigTest,
         contextUrl = ExampleApp.contextUrl,
         appName = metricsName
-      )(actorSystem.getOrElse(defaultActorSystem), ec)
+      )(actorSystem.getOrElse(defaultActorSystem), global)
 
       app.run()
 

--- a/http/src/test/scala/weco/http/models/ContextResponseTest.scala
+++ b/http/src/test/scala/weco/http/models/ContextResponseTest.scala
@@ -5,12 +5,14 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 
+import java.net.URL
+
 class ContextResponseTest extends AnyFunSpec with Matchers with JsonAssertions {
   it("adds the context URL to a response") {
     case class Shape(sides: Int, color: String)
 
     val resp = ContextResponse(
-      context = "http://example.org/context.json",
+      contextUrl = new URL("http://example.org/context.json"),
       result = Shape(sides = 3, color = "blue")
     )
 


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/5164

We have context URLs defined in a bunch of different ways: as a string, as a URL, as a variable called `context` or `contextURL` or `contextUrl`. All of this gets extra fiddly and dull for a thing we don't care that much about.

This PR establishes a standard for defining context URLs, and I'll clean up the other services to match.