### PR TITLE
Allow setting contextUrl for assertIsDisplayError

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Fix assertIsDisplayError

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -1,5 +1,7 @@
 package weco.http
 
+import java.net.URL
+
 import akka.http.scaladsl.model.StatusCodes.{BadRequest, InternalServerError, NotFound}
 import akka.http.scaladsl.model._
 import org.scalatest.concurrent.IntegrationPatience
@@ -14,6 +16,8 @@ class WellcomeHttpAppFeatureTest
     with IntegrationPatience {
 
   import weco.http.fixtures.ExampleApp._
+
+  override val contextUrl: URL = weco.http.fixtures.ExampleApp.contextUrl
 
   describe("GET") {
     it("responds to a request") {

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -17,7 +17,7 @@ class WellcomeHttpAppFeatureTest
 
   import weco.http.fixtures.ExampleApp._
 
-  override val contextUrl: URL = weco.http.fixtures.ExampleApp.contextUrl
+  override def contextUrl: URL = weco.http.fixtures.ExampleApp.contextUrl
 
   describe("GET") {
     it("responds to a request") {

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -139,7 +139,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         jsonResponse,
         s"""
            |{
-           |  "@context": "${contextUrl}",
+           |  "@context": "$contextUrl",
            |  "errorType": "http",
            |  "httpStatus": ${statusCode.intValue()},
            |  "label": "${statusCode.reason()}",

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -1,5 +1,7 @@
 package weco.http.fixtures
 
+import java.net.URL
+
 import akka.actor.ActorSystem
 import org.scalatest.Assertion
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
@@ -23,6 +25,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait HttpFixtures extends Akka with ScalaFutures with Matchers
   with JsonAssertions{
+
+  val contextUrl: URL
 
   private def whenRequestReady[R](
     r: HttpRequest
@@ -135,7 +139,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         jsonResponse,
         s"""
            |{
-           |  "@context": "${ExampleApp.contextUrl}",
+           |  "@context": "${contextUrl}",
            |  "errorType": "http",
            |  "httpStatus": ${statusCode.intValue()},
            |  "label": "${statusCode.reason()}",

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -26,7 +26,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait HttpFixtures extends Akka with ScalaFutures with Matchers
   with JsonAssertions{
 
-  val contextUrl: URL
+  def contextUrl: URL
 
   private def whenRequestReady[R](
     r: HttpRequest


### PR DESCRIPTION
This makes `assertIsDisplayError` work outside scala-libs.

For https://github.com/wellcomecollection/platform/issues/5162