### PR TITLE
Don't expect a 'description: null' in display errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Change assertDisplayError() so it doesn't expect `"description": null` in the JSON output if there is no description.

--- a/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
@@ -7,7 +7,10 @@ import weco.http.json.DisplayJsonUtil
 import weco.http.models.{ContextResponse, DisplayError}
 import weco.http.monitoring.HttpMetrics
 
-trait WellcomeExceptionHandler extends Logging with HasContextUrl with DisplayJsonUtil {
+trait WellcomeExceptionHandler
+    extends Logging
+    with HasContextUrl
+    with DisplayJsonUtil {
   import akka.http.scaladsl.server.Directives._
   import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 

--- a/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
+++ b/http/src/main/scala/weco/http/WellcomeExceptionHandler.scala
@@ -3,13 +3,13 @@ package weco.http
 import akka.http.scaladsl.model.StatusCodes.InternalServerError
 import akka.http.scaladsl.server.ExceptionHandler
 import grizzled.slf4j.Logging
+import weco.http.json.DisplayJsonUtil
 import weco.http.models.{ContextResponse, DisplayError}
 import weco.http.monitoring.HttpMetrics
 
-trait WellcomeExceptionHandler extends Logging with HasContextUrl {
+trait WellcomeExceptionHandler extends Logging with HasContextUrl with DisplayJsonUtil {
   import akka.http.scaladsl.server.Directives._
   import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-  import uk.ac.wellcome.json.JsonUtil._
 
   val httpMetrics: HttpMetrics
 

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -59,7 +59,7 @@ class WellcomeHttpAppFeatureTest
     }
 
     it("returns an InternalServerError if an exception is thrown") {
-      withApp(brokenGetExampleApi.routes) { _ =>
+      withApp(brokenExampleApi.routes) { _ =>
         val path = "/example"
         whenGetRequestReady(path) { response =>
           assertIsDisplayError(
@@ -164,7 +164,7 @@ class WellcomeHttpAppFeatureTest
     }
 
     it("returns an InternalServerError if an exception is thrown") {
-      withApp(brokenGetExampleApi.routes) { _ =>
+      withApp(brokenExampleApi.routes) { _ =>
 
         val entity = HttpEntity(
           contentType = ContentTypes.`application/json`,

--- a/http/src/test/scala/weco/http/fixtures/ExampleApp.scala
+++ b/http/src/test/scala/weco/http/fixtures/ExampleApp.scala
@@ -42,7 +42,7 @@ object ExampleApp {
     override def postTransform(exampleResource: ExampleResource): String = "ok"
   }
 
-  val brokenGetExampleApi = new ExampleApi {
+  val brokenExampleApi = new ExampleApi {
     override def getTransform(): ExampleResource = throw new Exception("BOOM!!!")
 
     override def postTransform(exampleResource: ExampleResource): String =


### PR DESCRIPTION
I had a quick look at the storage-service issues, and I think the problem boils down to:

* The bags API is omitting the `"description"` key in the error JSON for internal server errors, because it's `null`
* The helpers in this library expect to see `"description": null` there

Whether you get it depends on which JSON encoder you use – we use `JsonUtil` for internal JSON, and `DisplayJsonUtil` for public-facing JSON. The former will serialise every key; the latter drops nulls. Switching out one use of JsonUtil for DisplayJsonUtil seems to get this on the right track.