### PR TITLE
Force people to supply a host/username/password

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The elasticsearch_typesafe library now requires that you configure at least a host, username and password.

--- a/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
+++ b/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
@@ -8,21 +8,16 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 object ElasticBuilder {
   def buildElasticClient(config: Config,
                          namespace: String = ""): ElasticClient = {
-    val hostname = config
-      .getStringOption(s"es.$namespace.host")
-      .getOrElse("localhost")
+    val hostname = config.requireString(s"es.$namespace.host")
+    val username = config.requireString(s"es.$namespace.username")
+    val password = config.requireString(s"es.$namespace.password")
+
     val port = config
       .getIntOption(s"es.$namespace.port")
       .getOrElse(9200)
     val protocol = config
       .getStringOption(s"es.$namespace.protocol")
       .getOrElse("http")
-    val username = config
-      .getStringOption(s"es.$namespace.username")
-      .getOrElse("username")
-    val password = config
-      .getStringOption(s"es.$namespace.password")
-      .getOrElse("password")
     val compressionEnabled = config
       .getBooleanOption(s"es.$namespace.compressionEnabled")
       .getOrElse(false)


### PR DESCRIPTION
An Elasticsearch client isn't useful without those things, so hard fail on startup if they aren't supplied.

I learnt this while trying (and failing) to deploy https://github.com/wellcomecollection/catalogue-api/issues/8