### PR TITLE
Remove example data from shared lib

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix contextUrl leaking into fixture

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -24,7 +24,7 @@ import weco.http.models.HTTPServerConfig
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait HttpFixtures extends Akka with ScalaFutures with Matchers
-  with JsonAssertions{
+  with JsonAssertions {
 
   def contextUrl: URL
 
@@ -169,7 +169,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
         routes = routes,
         httpMetrics = httpMetrics.getOrElse(defaultHttpMetrics),
         httpServerConfig = httpServerConfigTest,
-        contextUrl = ExampleApp.contextUrl,
+        contextUrl = contextUrl,
         appName = metricsName
       )(actorSystem.getOrElse(defaultActorSystem), global)
 


### PR DESCRIPTION
Fix for example data leaking into shared withApp function.