### PR TITLE
Add TimeAssertions to the shared fixtures library

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This adds TimeAssertions to the fixtures library.

--- a/fixtures/src/test/scala/weco/fixtures/TimeAssertions.scala
+++ b/fixtures/src/test/scala/weco/fixtures/TimeAssertions.scala
@@ -1,0 +1,16 @@
+package weco.fixtures
+
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+
+import java.time.{Duration, Instant}
+
+trait TimeAssertions extends Matchers {
+  def assertRecent(instant: Instant, recentSeconds: Int = 1): Assertion =
+    Duration
+      .between(instant, Instant.now)
+      .getSeconds should be <= recentSeconds.toLong
+
+  def assertAllRecent(instants: Seq[Instant], recentSeconds: Int = 1): Unit =
+    instants.foreach(i => assertRecent(i, recentSeconds))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,11 +72,16 @@ object Dependencies {
     "com.sksamuel.elastic4s" %% "elastic4s-testkit" % versions.elastic4s % "test"
   )
 
-  val testDependencies = Seq(
-    "org.scalatest" %% "scalatest" % versions.scalatest % Test,
+  val scalatestDependencies = Seq(
+    "org.scalatest" %% "scalatest" % versions.scalatest % Test
+  )
+
+  val mockitoDependencies = Seq(
     "org.scalatestplus" %% versions.scalatestPlusMockitoArtifactId % versions.scalatestPlus % Test,
     "org.mockito" % "mockito-core" % versions.mockito % Test
   )
+
+  val testDependencies: Seq[ModuleID] = scalatestDependencies ++ mockitoDependencies
 
   val sl4jDependencies = Seq(
     "org.clapper" %% "grizzled-slf4j" % versions.grizzled
@@ -162,8 +167,9 @@ object Dependencies {
       sl4jDependencies ++
       testDependencies
 
-  val fixturesDependencies =
-    sl4jDependencies
+  val fixturesDependencies: Seq[ModuleID] =
+    sl4jDependencies ++
+      scalatestDependencies
 
   val typesafeAppDependencies =
     akkaDependencies ++


### PR DESCRIPTION
We have this in several places across our repos now and it's quite useful.