### PR TITLE
Create a TypedString type for values that are more than strings, but barely

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Add a TypedString type for times when we want to use a type in place of a string, but we still want the value to serialise as a string in JSON/DynamoDB.
+
+We already have code for this in various places; this consolidates it into one place.

--- a/json/src/main/scala/weco/json/TypedString.scala
+++ b/json/src/main/scala/weco/json/TypedString.scala
@@ -48,7 +48,7 @@ trait TypedString[T <: TypedString[_]] {
 
   override def equals(that: Any): Boolean =
     that match {
-      case that if that.getClass == this.getClass =>
+      case that if this.canEqual(that) =>
         this.underlying == that.asInstanceOf[T].underlying
       case _ => false
     }

--- a/json/src/main/scala/weco/json/TypedString.scala
+++ b/json/src/main/scala/weco/json/TypedString.scala
@@ -1,0 +1,67 @@
+package weco.json
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/** In a number of cases, we have "meaningful" strings -- i.e., strings where the
+  * value has some meaning, and isn't just opaque text.
+  *
+  * e.g. a canonical ID in the catalogue, an external identifier in the storage
+  * service
+  *
+  * Within our code, it's useful to create a special type for these strings,
+  * so we get the benefit of the type checker.  We could use a case class, e.g.
+  *
+  *     case class Shape(name: String)
+  *
+  * but then we'll get the automatic Circe case class JSON encoder/decoder, which
+  * adds an unnecessary layer of indirection:
+  *
+  *     {"name": "square"}
+  *
+  * we would rather encode/decode these to raw strings in JSON, which is slightly
+  * easier to work with.  It also retains backwards compatibility with old data,
+  * if we "upgrade" a value from `String` to a `TypedString[_]`.
+  *
+  * You can define custom encoders/decoders on a regular case class, but then you
+  * have to make sure they're in scope.  If you get this wrong, you get mismatched
+  * serialisations, which is a world of pain.
+  *
+  * This class allows you to create "meaningful" strings that serialise to raw strings
+  * in JSON.  It also handles some of the things you get for "free" with case classes,
+  * e.g. equality and hashing.
+  *
+  *     class Shape(val underlying: String) extends TypedString[Shape]
+  *
+  *     object Shape extends TypedStringOps[Shape] {
+  *       override def apply(name: String): Shape = new Shape(name)
+  *     }
+  *
+  * See also: TypedStringScanamoOps in the storage lib, which provides a DynamoDB format.
+  *
+  */
+trait TypedString[T <: TypedString[_]] {
+  val underlying: String
+
+  override def toString: String = underlying
+
+  def canEqual(a: Any): Boolean = a.getClass == this.getClass
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that if that.getClass == this.getClass =>
+        this.underlying == that.asInstanceOf[T].underlying
+      case _ => false
+    }
+
+  override def hashCode: Int = underlying.hashCode
+}
+
+trait TypedStringOps[T <: TypedString[_]] {
+  def apply(underlying: String): T
+
+  implicit val encoder: Encoder[T] =
+    (value: T) => Json.fromString(value.toString)
+
+  implicit val decoder: Decoder[T] = (cursor: HCursor) =>
+    cursor.value.as[String].map(apply)
+}

--- a/json/src/test/scala/weco/json/TypedStringTest.scala
+++ b/json/src/test/scala/weco/json/TypedStringTest.scala
@@ -1,0 +1,84 @@
+package weco.json
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+class TypedStringTest extends AnyFunSpec with Matchers with JsonAssertions {
+  class Shape(val underlying: String) extends TypedString[Shape]
+
+  object Shape extends TypedStringOps[Shape] {
+    override def apply(name: String): Shape = new Shape(name)
+  }
+
+  class Pattern(val underlying: String) extends TypedString[Pattern]
+
+  object Pattern extends TypedStringOps[Pattern] {
+    override def apply(name: String): Pattern = new Pattern(name)
+  }
+
+  describe("equality") {
+    it("an instance is equal to itself") {
+      val circle = Shape("circle")
+
+      circle shouldBe circle
+
+      (circle == circle) shouldBe true
+      (circle != circle) shouldBe false
+    }
+
+    it("equal values are equal") {
+      Shape("circle") shouldBe Shape("circle")
+
+      (Shape("circle") == Shape("circle")) shouldBe true
+      (Shape("circle") != Shape("circle")) shouldBe false
+    }
+
+    it("unequal values are not equal") {
+      Shape("circle") should not be Shape("square")
+
+      (Shape("circle") == Shape("square")) shouldBe false
+      (Shape("circle") != Shape("square")) shouldBe true
+    }
+
+    it("equal values, different types are not equal") {
+      Shape("circle") should not be Pattern("circle")
+
+      (Shape("circle") == Pattern("circle")) shouldBe false
+      (Shape("circle") != Pattern("circle")) shouldBe true
+    }
+
+    it("is not equal to a string") {
+      Shape("circle") should not be "circle"
+
+      (Shape("circle") == "circle") shouldBe false
+      (Shape("circle") != "circle") shouldBe true
+    }
+  }
+
+  describe("JSON encoding/decoding") {
+    it("round trips to JSON") {
+      val square = Shape("square")
+
+      val jsonString = toJson(square).get
+      fromJson[Shape](jsonString).get shouldBe square
+    }
+
+    it("serialises to a string") {
+      val triangle = Shape("triangle")
+
+      assertJsonStringsAreEqual(toJson(triangle).get,
+        """
+          |"triangle"
+          |""".stripMargin)
+    }
+
+    it("deserialises from a string") {
+      fromJson[Shape](
+        """
+          |"pentagon"
+          |""".stripMargin).get shouldBe Shape("pentagon")
+    }
+  }
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/TypedStringScanamoOps.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/TypedStringScanamoOps.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.storage
+
+import org.scanamo.DynamoFormat
+import weco.json.{TypedString, TypedStringOps}
+
+trait TypedStringScanamoOps[T <: TypedString[_]] extends TypedStringOps[T] {
+  implicit def evidence: DynamoFormat[T] =
+    DynamoFormat
+      .coercedXmap[T, String, IllegalArgumentException](
+        apply,
+        _.underlying
+      )
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/TypedStringScanamoOpsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/TypedStringScanamoOpsTest.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.storage
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.{DynamoFormat, DynamoValue}
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import weco.json.TypedString
+
+class TypedStringScanamoOpsTest extends AnyFunSpec with Matchers with EitherValues {
+  class Shape(val underlying: String) extends TypedString[Shape]
+
+  object Shape extends TypedStringScanamoOps[Shape] {
+    override def apply(name: String): Shape = new Shape(name)
+  }
+
+  describe("Dynamo encoding/decoding") {
+    it("round trips to Dynamo") {
+      val square = Shape("square")
+
+      val attributeValue = DynamoFormat[Shape].write(square)
+      DynamoFormat[Shape].read(attributeValue).value shouldBe square
+    }
+
+    it("serialises to a string") {
+      val triangle = Shape("triangle")
+
+      DynamoFormat[Shape].write(triangle) shouldBe DynamoValue.fromString("triangle")
+    }
+
+    it("deserialises from a string") {
+      val av = AttributeValue.builder().s("pentagon").build()
+
+      DynamoFormat[Shape].read(av).value shouldBe Shape("pentagon")
+    }
+  }
+}


### PR DESCRIPTION
This is spun out of a comment on https://github.com/wellcomecollection/catalogue-pipeline/pull/1607#discussion_r631735484

Is this behaviour useful? Yes, I think so.

Should it be copied in a dozen different places? Definitely not.