### PR TITLE
Copy across the classes for HTTP client-related stuff

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This adds HTTP client-related classes from the catalogue-api repo.

--- a/http/src/main/scala/weco/http/client/AkkaHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/AkkaHttpClient.scala
@@ -1,0 +1,14 @@
+package weco.http.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem,
+                                       val ec: ExecutionContext)
+  extends HttpClient {
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
+    Http().singleRequest(request)
+}

--- a/http/src/main/scala/weco/http/client/AkkaHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/AkkaHttpClient.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem,
                                        val ec: ExecutionContext)
-  extends HttpClient {
+    extends HttpClient {
   override def singleRequest(request: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request)
 }

--- a/http/src/main/scala/weco/http/client/HttpClient.scala
+++ b/http/src/main/scala/weco/http/client/HttpClient.scala
@@ -38,8 +38,8 @@ trait HttpClient {
                body: Option[In] = None,
                params: Map[String, String] = Map.empty,
                headers: List[HttpHeader] = Nil)(
-                implicit encoder: Encoder[In]
-              ): Future[HttpResponse] = {
+    implicit encoder: Encoder[In]
+  ): Future[HttpResponse] = {
     implicit val um: ToEntityMarshaller[In] = CirceMarshalling.fromEncoder[In]
 
     for {

--- a/http/src/main/scala/weco/http/client/HttpClient.scala
+++ b/http/src/main/scala/weco/http/client/HttpClient.scala
@@ -1,0 +1,61 @@
+package weco.http.client
+
+import akka.http.scaladsl.marshalling.{Marshal, ToEntityMarshaller}
+import akka.http.scaladsl.model.Uri.Path.Slash
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model._
+import io.circe.Encoder
+import weco.http.json.CirceMarshalling
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait HttpClient {
+  val baseUri: Uri
+
+  implicit val ec: ExecutionContext
+
+  def singleRequest(request: HttpRequest): Future[HttpResponse]
+
+  private def buildUri(
+    path: Path,
+    params: Map[String, String]
+  ): Uri =
+    baseUri
+      .withPath(baseUri.path ++ Slash(path))
+      .withQuery(Query(params))
+
+  def get(path: Path,
+          params: Map[String, String] = Map.empty): Future[HttpResponse] = {
+    val request = HttpRequest(
+      method = HttpMethods.GET,
+      uri = buildUri(path, params)
+    )
+
+    singleRequest(request)
+  }
+
+  def post[In](path: Path,
+               body: Option[In] = None,
+               params: Map[String, String] = Map.empty,
+               headers: List[HttpHeader] = Nil)(
+                implicit encoder: Encoder[In]
+              ): Future[HttpResponse] = {
+    implicit val um: ToEntityMarshaller[In] = CirceMarshalling.fromEncoder[In]
+
+    for {
+      entity <- body match {
+        case Some(body) => Marshal(body).to[RequestEntity]
+        case None       => Future.successful(HttpEntity.Empty)
+      }
+
+      request = HttpRequest(
+        HttpMethods.POST,
+        uri = buildUri(path, params),
+        headers = headers,
+        entity = entity
+      )
+
+      response <- singleRequest(request)
+    } yield response
+  }
+}

--- a/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
@@ -1,0 +1,27 @@
+package weco.http.client
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import scala.concurrent.{ExecutionContext, Future}
+
+class MemoryHttpClient(
+  responses: Seq[(HttpRequest, HttpResponse)]
+)(
+  implicit val ec: ExecutionContext
+) extends HttpClient {
+
+  val baseUri: Uri = Uri("http://sierra:1234")
+
+  private val iterator = responses.toIterator
+
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
+    Future {
+      val (nextReq, nextResp) = iterator.next()
+
+      if (nextReq != request) {
+        throw new RuntimeException(
+          s"Expected request $nextReq, but got $request")
+      }
+
+      nextResp
+    }
+}

--- a/http/src/main/scala/weco/http/client/sierra/SierraAccessToken.scala
+++ b/http/src/main/scala/weco/http/client/sierra/SierraAccessToken.scala
@@ -1,0 +1,11 @@
+package weco.http.client.sierra
+
+import io.circe.generic.extras.JsonKey
+
+// This represents a response from the Client Credentials flow, as described
+// in the Sierra docs:
+// https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
+case class SierraAccessToken(
+  @JsonKey("access_token") accessToken: String,
+  @JsonKey("expires_in") expiresIn: Int
+)

--- a/http/src/main/scala/weco/http/client/sierra/SierraOauthHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/sierra/SierraOauthHttpClient.scala
@@ -3,7 +3,11 @@ package weco.http.client.sierra
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
+import akka.http.scaladsl.model.headers.{
+  Authorization,
+  BasicHttpCredentials,
+  OAuth2BearerToken
+}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
 import weco.http.client.HttpClient
 import weco.http.json.CirceMarshalling
@@ -20,7 +24,7 @@ class SierraOauthHttpClient(
   val system: ActorSystem,
   val ec: ExecutionContext
 ) extends HttpClient
-  with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
+    with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
 
   override val baseUri: Uri = underlying.baseUri
 
@@ -37,8 +41,8 @@ class SierraOauthHttpClient(
   // to fetch a new token.
   //
   override protected def getNewToken(
-                                      credentials: BasicHttpCredentials
-                                    ): Future[(OAuth2BearerToken, Instant)] =
+    credentials: BasicHttpCredentials
+  ): Future[(OAuth2BearerToken, Instant)] =
     for {
       tokenResponse <- underlying.post[Unit](
         path = tokenPath,

--- a/http/src/main/scala/weco/http/client/sierra/SierraOauthHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/sierra/SierraOauthHttpClient.scala
@@ -1,0 +1,80 @@
+package weco.http.client.sierra
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
+import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
+import weco.http.client.HttpClient
+import weco.http.json.CirceMarshalling
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+class SierraOauthHttpClient(
+  underlying: HttpClient,
+  val tokenPath: Path = Path("v5/token"),
+  val credentials: BasicHttpCredentials
+)(
+  implicit
+  val system: ActorSystem,
+  val ec: ExecutionContext
+) extends HttpClient
+  with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
+
+  override val baseUri: Uri = underlying.baseUri
+
+  import uk.ac.wellcome.json.JsonUtil._
+
+  implicit val um: FromEntityUnmarshaller[SierraAccessToken] =
+    CirceMarshalling.fromDecoder[SierraAccessToken]
+
+  // This implements the Client Credentials flow, as described in the Sierra docs:
+  // https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
+  //
+  // We make a request with a client key and secret, retrieve an access token which
+  // lasts an hour, and use that for future requests.  When the hour is up, we have
+  // to fetch a new token.
+  //
+  override protected def getNewToken(
+                                      credentials: BasicHttpCredentials
+                                    ): Future[(OAuth2BearerToken, Instant)] =
+    for {
+      tokenResponse <- underlying.post[Unit](
+        path = tokenPath,
+        headers = List(Authorization(credentials))
+      )
+
+      accessToken <- Unmarshal(tokenResponse).to[SierraAccessToken]
+
+      result = (
+        OAuth2BearerToken(accessToken.accessToken),
+        Instant.now().plusSeconds(accessToken.expiresIn)
+      )
+    } yield result
+
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
+    for {
+      token <- getToken(credentials)
+
+      authenticatedRequest = {
+        // We're going to set our own Authorization header on this request
+        // using the token, so there shouldn't be one already.
+        //
+        // Are multiple Authorization headers allowed by HTTP?  It doesn't matter,
+        // it's not something we should be doing.
+        val existingAuthHeaders = request.headers.collect {
+          case auth: Authorization => auth
+        }
+        require(
+          existingAuthHeaders.isEmpty,
+          s"HTTP request already has auth headers: $request")
+
+        request.copy(
+          headers = request.headers :+ Authorization(token)
+        )
+      }
+
+      response <- underlying.singleRequest(authenticatedRequest)
+    } yield response
+}

--- a/http/src/main/scala/weco/http/client/sierra/TokenExchange.scala
+++ b/http/src/main/scala/weco/http/client/sierra/TokenExchange.scala
@@ -17,9 +17,9 @@ trait TokenExchange[C, T] {
   def getToken(credentials: C): Future[T] =
     cachedToken match {
       case Some((token, expiryTime))
-        if expiryTime
-          .minusSeconds(expiryGracePeriod)
-          .isAfter(Instant.now()) =>
+          if expiryTime
+            .minusSeconds(expiryGracePeriod)
+            .isAfter(Instant.now()) =>
         Future.successful(token)
 
       case _ =>

--- a/http/src/main/scala/weco/http/client/sierra/TokenExchange.scala
+++ b/http/src/main/scala/weco/http/client/sierra/TokenExchange.scala
@@ -1,0 +1,32 @@
+package weco.http.client.sierra
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+trait TokenExchange[C, T] {
+  private var cachedToken: Option[(T, Instant)] = None
+
+  // How many seconds before the token expires should we go back and
+  // fetch a new token?
+  protected val expiryGracePeriod: Int = 60
+
+  implicit val ec: ExecutionContext
+
+  protected def getNewToken(credentials: C): Future[(T, Instant)]
+
+  def getToken(credentials: C): Future[T] =
+    cachedToken match {
+      case Some((token, expiryTime))
+        if expiryTime
+          .minusSeconds(expiryGracePeriod)
+          .isAfter(Instant.now()) =>
+        Future.successful(token)
+
+      case _ =>
+        getNewToken(credentials).map {
+          case (token, expiryTime) =>
+            cachedToken = Some((token, expiryTime))
+            token
+        }
+    }
+}

--- a/http/src/main/scala/weco/http/json/CirceMarshalling.scala
+++ b/http/src/main/scala/weco/http/json/CirceMarshalling.scala
@@ -1,0 +1,36 @@
+package weco.http.json
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import io.circe.{Decoder, Encoder}
+import io.circe.syntax._
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.concurrent.Future
+
+/** This class gives us helpers for using Circe to marshall/unmarshall JSON
+  * using our Circe decoders and encoders.
+  *
+  * This is helpful for a few reasons:
+  *
+  *   1.  The default [Un]marshallers aren't aware of all of Circe's features,
+  *       e.g. the @JsonKey annotation.
+  *   2.  It means that any method doing akka-http marshalling can just require
+  *       an implicit Decoder[T] or Encoder[T], which is a more common interface
+  *       in our codebase.
+  *
+  */
+object CirceMarshalling {
+  def fromDecoder[T: Decoder]: Unmarshaller[HttpEntity, T] =
+    Unmarshaller.stringUnmarshaller
+      .forContentTypes(ContentTypes.`application/json`)
+      .flatMap { _ => _ => json =>
+        Future.fromTry(fromJson[T](json))
+      }
+
+  def fromEncoder[T: Encoder]: ToEntityMarshaller[T] =
+    Marshaller.withFixedContentType(ContentTypes.`application/json`) { t =>
+      HttpEntity(ContentTypes.`application/json`, t.asJson.noSpaces)
+    }
+}

--- a/http/src/test/scala/weco/http/client/sierra/TokenExchangeTest.scala
+++ b/http/src/test/scala/weco/http/client/sierra/TokenExchangeTest.scala
@@ -1,0 +1,91 @@
+package weco.http.client.sierra
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
+
+class TokenExchangeTest extends AnyFunSpec with Matchers with ScalaFutures {
+  type Credentials = String
+  type Token = String
+
+  class MemoryTokenExchange(
+                             tokens: Seq[(Credentials, Instant)]
+                           )(implicit val ec: ExecutionContext)
+    extends TokenExchange[Credentials, Token] {
+    var calls = 0
+    override protected val expiryGracePeriod = 0
+
+    override protected def getNewToken(
+                                        credentials: Credentials): Future[(Token, Instant)] =
+      synchronized {
+        val index = calls
+        calls += 1
+
+        Future.fromTry(Try(tokens(index)))
+      }
+  }
+
+  val credentials = "password"
+
+  val now = Instant.now()
+
+  it("retrieves a token") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now)
+      )
+    )
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token1"
+    }
+  }
+
+  it("caches a token, and doesn't fetch it again until it expires") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now.plusSeconds(1)),
+        ("token2", now)
+      )
+    )
+
+    // Get the token three times, verify we get the same token each time,
+    // but that the underlying method was only called once.
+    whenReady(exchange.getToken(credentials)) { resp1 =>
+      resp1 shouldBe "token1"
+
+      whenReady(exchange.getToken(credentials)) { resp2 =>
+        resp2 shouldBe "token1"
+
+        whenReady(exchange.getToken(credentials)) { resp3 =>
+          resp3 shouldBe "token1"
+        }
+      }
+    }
+
+    exchange.calls shouldBe 1
+
+    // Now wait for the existing token to expire, and check we can fetch the new token
+    Thread.sleep(1500)
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token2"
+    }
+
+    exchange.calls shouldBe 2
+  }
+
+  it("fails if there is no cached token and the underlying lookup fails") {
+    val brokenExchange = new MemoryTokenExchange(tokens = Seq.empty)
+
+    whenReady(brokenExchange.getToken(credentials).failed) {
+      _ shouldBe a[IndexOutOfBoundsException]
+    }
+  }
+}
+


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5192

We use similar code in:

* the items and requests API in the catalogue API
* the Calm and Sierra adapters in the catalogue pipeline
* the bag/ingest tracker clients in the storage service

This is another step towards consolidating all the code that makes HTTP requests.