### PR TITLE
Provide a better error message if you pass invalid JSON to HttpFixtures.createJsonHttpEntityWith()

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Provide a better error message if you pass invalid JSON to HttpFixtures.createJsonHttpEntityWith().

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -51,10 +51,13 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
   }
 
   def createJsonHttpEntityWith(jsonString: String): RequestEntity =
-    HttpEntity(
-      ContentTypes.`application/json`,
-      parse(jsonString).right.get.noSpaces
-    )
+    parse(jsonString) match {
+      case Right(json) =>
+        HttpEntity(ContentTypes.`application/json`, json.noSpaces)
+
+      case Left(err) =>
+        throw new IllegalArgumentException(s"Unable to parse JSON ($err):\n$jsonString")
+    }
 
   def whenPostRequestReady[R](
                                path: String,


### PR DESCRIPTION
I just made this mistake; a better error message would have been helpful.