### PR TITLE
Be more tolerant of equality when comparing JSON entities in MemoryHttpClient

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Be a bit more tolerant of equality when comparing JSON entities in MemoryHttpClient.

--- a/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
@@ -1,6 +1,11 @@
 package weco.http.client
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpRequest,
+  HttpResponse
+}
 import akka.util.ByteString
 import io.circe.Json
 import io.circe.parser.parse
@@ -26,7 +31,6 @@ class MemoryHttpClient(
           s"Expected request with method ${nextReq.method}, got method with URI ${request.method}")
       }
 
-
       if (nextReq.uri != request.uri) {
         throw new RuntimeException(
           s"Expected request with URI ${nextReq.uri}, got request with URI ${request.uri}")
@@ -38,7 +42,8 @@ class MemoryHttpClient(
       }
 
       if (!areEquivalent(nextReq.entity, request.entity)) {
-        throw new RuntimeException(s"Requests have different entities: ${nextReq.entity} / ${request.entity}")
+        throw new RuntimeException(
+          s"Requests have different entities: ${nextReq.entity} / ${request.entity}")
       }
 
       nextResp
@@ -48,8 +53,11 @@ class MemoryHttpClient(
     (e1, e2) match {
       case (entity1, entity2) if entity1 == entity2 => true
 
-      case (HttpEntity.Strict(ContentTypes.`application/json`, json1), HttpEntity.Strict(ContentTypes.`application/json`, json2))
-        if parseOrElse(json1) == parseOrElse(json2) => true
+      case (
+          HttpEntity.Strict(ContentTypes.`application/json`, json1),
+          HttpEntity.Strict(ContentTypes.`application/json`, json2))
+          if parseOrElse(json1) == parseOrElse(json2) =>
+        true
 
       case _ => false
     }

--- a/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
@@ -1,6 +1,10 @@
 package weco.http.client
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
+import akka.util.ByteString
+import io.circe.Json
+import io.circe.parser.parse
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class MemoryHttpClient(
@@ -17,6 +21,11 @@ class MemoryHttpClient(
 
       // These checks all amount to "nextReq != request", but the specific
       // checks are meant to make it easier to debug particular issues.
+      if (nextReq.method != request.method) {
+        throw new RuntimeException(
+          s"Expected request with method ${nextReq.method}, got method with URI ${request.method}")
+      }
+
 
       if (nextReq.uri != request.uri) {
         throw new RuntimeException(
@@ -28,11 +37,28 @@ class MemoryHttpClient(
           s"Expected request with headers ${nextReq.headers}, got request with headers ${request.headers}")
       }
 
-      if (nextReq != request) {
-        throw new RuntimeException(
-          s"Expected request $nextReq, but got $request")
+      if (!areEquivalent(nextReq.entity, request.entity)) {
+        throw new RuntimeException(s"Requests have different entities: ${nextReq.entity} / ${request.entity}")
       }
 
       nextResp
+    }
+
+  private def areEquivalent(e1: HttpEntity, e2: HttpEntity): Boolean =
+    (e1, e2) match {
+      case (entity1, entity2) if entity1 == entity2 => true
+
+      case (HttpEntity.Strict(ContentTypes.`application/json`, json1), HttpEntity.Strict(ContentTypes.`application/json`, json2))
+        if parseOrElse(json1) == parseOrElse(json2) => true
+
+      case _ => false
+    }
+
+  private def parseOrElse(json: ByteString): Json =
+    parse(new String(json.toArray[Byte])) match {
+      case Right(t) => t
+      case Left(err) =>
+        println(s"Error trying to parse string <<$json>>")
+        throw err
     }
 }

--- a/http/src/test/scala/weco/http/client/MemoryHttpClientTest.scala
+++ b/http/src/test/scala/weco/http/client/MemoryHttpClientTest.scala
@@ -1,0 +1,50 @@
+package weco.http.client
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes, Uri}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MemoryHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures {
+  it("treats request entities as similar if they have the same JSON") {
+    val client = new MemoryHttpClient(
+      responses = Seq(
+        (
+          HttpRequest(
+            method = HttpMethods.POST,
+            uri = Uri("http://example.net/shape"),
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                 |{
+                 |  "color": "red",
+                 |  "sides": 4
+                 |}
+                 |""".stripMargin
+            )
+          ),
+          HttpResponse(status = StatusCodes.Created)
+        )
+      )
+    )
+
+    val future = client.singleRequest(
+      HttpRequest(
+        method = HttpMethods.POST,
+        uri = Uri("http://example.net/shape"),
+        entity = HttpEntity(
+          contentType = ContentTypes.`application/json`,
+          """
+             |{"color": "red","sides": 4}
+             |""".stripMargin
+        )
+      )
+    )
+
+    whenReady(future) {
+      _.status shouldBe StatusCodes.Created
+    }
+  }
+}


### PR DESCRIPTION
This will save me fiddling to try to guess the exactly correct
serialisation when writing expected requests.