### PR TITLE
Automatically open downstream PRs for new releases of scala-libs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,15 @@
 steps:
   - label: "open downstream PRs"
-    command: "python3 .buildkite/scripts/open_downstream_prs.py"
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/open_downstream_prs.py"
 # steps:
 #   - label: format
 #     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,304 +1,304 @@
 steps:
+  - label: format
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/format.py"
+  - wait
+  - label: test fixtures
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project fixtures", "test"]
+  - label: test http
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project http", "test"]
+  - label: test json
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project json", "test"]
+  - label: test typesafe_app
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project typesafe_app", "test"]
+  - label: test messaging
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
+  - label: test messaging_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project messaging_typesafe", "test"]
+  - label: test storage
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project storage", "dockerComposeUp", "test", "dockerComposeStop"]
+  - label: test storage_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project storage_typesafe", "test"]
+  - label: test elasticsearch
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
+  - label: test elasticsearch_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          command: ["project elasticsearch_typesafe", "test"]
+  - wait
+  - label: cut release
+    if: build.branch == "main"
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/release.py"
+  - wait
+  - label: publish fixtures
+    if: build.branch == "main"
+    env:
+      PROJECT: fixtures
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish http
+    if: build.branch == "main"
+    env:
+      PROJECT: http
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish http_typesafe
+    if: build.branch == "main"
+    env:
+      PROJECT: http_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish json
+    if: build.branch == "main"
+    env:
+      PROJECT: json
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish typesafe_app
+    if: build.branch == "main"
+    env:
+      PROJECT: typesafe_app
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish messaging
+    if: build.branch == "main"
+    env:
+      PROJECT: messaging
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish messaging_typesafe
+    if: build.branch == "main"
+    env:
+      PROJECT: messaging_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish monitoring
+    if: build.branch == "main"
+    env:
+      PROJECT: monitoring
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish monitoring_typesafe
+    if: build.branch == "main"
+    env:
+      PROJECT: monitoring_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish storage
+    if: build.branch == "main"
+    env:
+      PROJECT: storage
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish storage_typesafe
+    if: build.branch == "main"
+    env:
+      PROJECT: storage_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish elasticseach
+    if: build.branch == "main"
+    env:
+      PROJECT: elasticsearch
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: publish elasticsearch_typesafe
+    if: build.branch == "main"
+    env:
+      PROJECT: elasticsearch_typesafe
+    plugins:
+      - docker#v3.5.0:
+          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+          mount-ssh-agent: true
+          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+          network: "host"
+          always-pull: true
+          propagate-environment: true
+          entrypoint: "/usr/bin/python3"
+    command: "/workdir/.buildkite/scripts/publish.py"
   - label: "open downstream PRs"
+    if: build.branch == "main"
     commands:
       - "pip3 install --user boto3 httpx"
       - "python3 .buildkite/scripts/open_downstream_prs.py"
-# steps:
-#   - label: format
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/format.py"
-#   - wait
-#   - label: test fixtures
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project fixtures", "test"]
-#   - label: test http
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project http", "test"]
-#   - label: test json
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project json", "test"]
-#   - label: test typesafe_app
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project typesafe_app", "test"]
-#   - label: test messaging
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
-#   - label: test messaging_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project messaging_typesafe", "test"]
-#   - label: test storage
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project storage", "dockerComposeUp", "test", "dockerComposeStop"]
-#   - label: test storage_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project storage_typesafe", "test"]
-#   - label: test elasticsearch
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
-#   - label: test elasticsearch_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           command: ["project elasticsearch_typesafe", "test"]
-#   - wait
-#   - label: cut release
-#     if: build.branch == "main"
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/release.py"
-#   - wait
-#   - label: publish fixtures
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: fixtures
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish http
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: http
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish http_typesafe
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: http_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish json
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: json
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish typesafe_app
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: typesafe_app
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish messaging
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: messaging
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish messaging_typesafe
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: messaging_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish monitoring
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: monitoring
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish monitoring_typesafe
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: monitoring_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish storage
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: storage
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish storage_typesafe
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: storage_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish elasticseach
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: elasticsearch
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"
-#   - label: publish elasticsearch_typesafe
-#     if: build.branch == "main"
-#     env:
-#       PROJECT: elasticsearch_typesafe
-#     plugins:
-#       - docker#v3.5.0:
-#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-#           mount-ssh-agent: true
-#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-#           network: "host"
-#           always-pull: true
-#           propagate-environment: true
-#           entrypoint: "/usr/bin/python3"
-#     command: "/workdir/.buildkite/scripts/publish.py"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,299 +1,302 @@
 steps:
-  - label: format
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/format.py"
-  - wait
-  - label: test fixtures
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project fixtures", "test"]
-  - label: test http
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project http", "test"]
-  - label: test json
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project json", "test"]
-  - label: test typesafe_app
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project typesafe_app", "test"]
-  - label: test messaging
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
-  - label: test messaging_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project messaging_typesafe", "test"]
-  - label: test storage
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project storage", "dockerComposeUp", "test", "dockerComposeStop"]
-  - label: test storage_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project storage_typesafe", "test"]
-  - label: test elasticsearch
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
-  - label: test elasticsearch_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          command: ["project elasticsearch_typesafe", "test"]
-  - wait
-  - label: cut release
-    if: build.branch == "main"
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/release.py"
-  - wait
-  - label: publish fixtures
-    if: build.branch == "main"
-    env:
-      PROJECT: fixtures
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish http
-    if: build.branch == "main"
-    env:
-      PROJECT: http
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish http_typesafe
-    if: build.branch == "main"
-    env:
-      PROJECT: http_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish json
-    if: build.branch == "main"
-    env:
-      PROJECT: json
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish typesafe_app
-    if: build.branch == "main"
-    env:
-      PROJECT: typesafe_app
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish messaging
-    if: build.branch == "main"
-    env:
-      PROJECT: messaging
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish messaging_typesafe
-    if: build.branch == "main"
-    env:
-      PROJECT: messaging_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish monitoring
-    if: build.branch == "main"
-    env:
-      PROJECT: monitoring
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish monitoring_typesafe
-    if: build.branch == "main"
-    env:
-      PROJECT: monitoring_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish storage
-    if: build.branch == "main"
-    env:
-      PROJECT: storage
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish storage_typesafe
-    if: build.branch == "main"
-    env:
-      PROJECT: storage_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish elasticseach
-    if: build.branch == "main"
-    env:
-      PROJECT: elasticsearch
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish elasticsearch_typesafe
-    if: build.branch == "main"
-    env:
-      PROJECT: elasticsearch_typesafe
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
+  - label: "open downstream PRs"
+    command: "python3 .buildkite/scripts/open_downstream_prs.py"
+# steps:
+#   - label: format
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/format.py"
+#   - wait
+#   - label: test fixtures
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project fixtures", "test"]
+#   - label: test http
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project http", "test"]
+#   - label: test json
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project json", "test"]
+#   - label: test typesafe_app
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project typesafe_app", "test"]
+#   - label: test messaging
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
+#   - label: test messaging_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project messaging_typesafe", "test"]
+#   - label: test storage
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project storage", "dockerComposeUp", "test", "dockerComposeStop"]
+#   - label: test storage_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project storage_typesafe", "test"]
+#   - label: test elasticsearch
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project messaging", "dockerComposeUp", "test", "dockerComposeStop"]
+#   - label: test elasticsearch_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           command: ["project elasticsearch_typesafe", "test"]
+#   - wait
+#   - label: cut release
+#     if: build.branch == "main"
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/release.py"
+#   - wait
+#   - label: publish fixtures
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: fixtures
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish http
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: http
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish http_typesafe
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: http_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish json
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: json
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish typesafe_app
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: typesafe_app
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish messaging
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: messaging
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish messaging_typesafe
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: messaging_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish monitoring
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: monitoring
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish monitoring_typesafe
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: monitoring_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish storage
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: storage
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish storage_typesafe
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: storage_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish elasticseach
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: elasticsearch
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"
+#   - label: publish elasticsearch_typesafe
+#     if: build.branch == "main"
+#     env:
+#       PROJECT: elasticsearch_typesafe
+#     plugins:
+#       - docker#v3.5.0:
+#           image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
+#           mount-ssh-agent: true
+#           volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+#           network: "host"
+#           always-pull: true
+#           propagate-environment: true
+#           entrypoint: "/usr/bin/python3"
+#     command: "/workdir/.buildkite/scripts/publish.py"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,8 @@
 steps:
   - label: "open downstream PRs"
-    plugins:
-      - docker#v3.5.0:
-          image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/open_downstream_prs.py"
+    commands:
+      - "pip3 install --user boto3 httpx"
+      - "python3 .buildkite/scripts/open_downstream_prs.py"
 # steps:
 #   - label: format
 #     plugins:

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -1,16 +1,52 @@
 #!/usr/bin/env python
 
+import contextlib
 import os
 import tempfile
 
 from commands import git
 
 
+@contextlib.contextmanager
+def working_directory(path):
+    """
+    Changes the working directory to the given path, then returns to the
+    original directory when done.
+    """
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+def update_scala_libs_version(new_version):
+    old_lines = list(open("project/Dependencies.scala"))
+
+    with open("project/Dependencies.scala", "w") as out_file:
+        for line in old_lines:
+            if line.startswith("    val defaultVersion"):
+                out_file.write(f'    val defaultVersion = "{new_version}"\n')
+            else:
+                out_file.write(line)
+
+
 if __name__ == '__main__':
     new_version = "v26.18.0"
 
-    for repo in ("catalogue-api", "pipeline", "storage-service"):
-        tmp_dir = tempfile.mkdtemp()
+    for repo in ("catalogue-api", "catalogue-pipeline", "storage-service"):
+        repo_dir = tempfile.mkdtemp()
 
-        git("clone", f"git@github.com:wellcomecollection/{repo}.git", tmp_dir)
+        git("clone", f"git@github.com:wellcomecollection/{repo}.git", repo_dir)
+
+        with working_directory(repo_dir):
+            update_scala_libs_version(new_version)
+
+            branch_name = f"bump-scala-libs-to-{new_version}"
+            git("checkout", "-b", branch_name)
+            git("add", "project/Dependencies.scala")
+            git("commit", "-m", f"Bump scala-libs to {new_version}")
+            git("push", "origin", branch_name)
+
         print(os.listdir(tmp_dir))

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
             git("commit", "-m", f"Bump scala-libs to {new_version}")
             git("push", "origin", branch_name)
 
-        print(os.listdir(tmp_dir))
+        break

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+
+from commands import git
+
+
+if __name__ == '__main__':
+    new_version = "v26.18.0"
+
+    for repo in ("catalogue-api", "pipeline", "storage-service"):
+        tmp_dir = tempfile.mkdtemp()
+
+        git("clone", f"git@github.com:wellcomecollection/{repo}.git", tmp_dir)
+        print(os.listdir(tmp_dir))

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -44,8 +44,8 @@ def update_scala_libs_version(new_version):
 
     with open("project/Dependencies.scala", "w") as out_file:
         for line in old_lines:
-            if line.startswith("    val defaultVersion"):
-                out_file.write(f'    val defaultVersion = "{new_version}"\n')
+            if line.startswith("  val defaultVersion"):
+                out_file.write(f'  val defaultVersion = "{new_version}"\n')
             else:
                 out_file.write(line)
 

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -63,7 +63,7 @@ def update_scala_libs_version(new_version):
     with open("project/Dependencies.scala", "w") as out_file:
         for line in old_lines:
             if line.startswith("  val defaultVersion"):
-                out_file.write(f'  val defaultVersion = "{new_version}"\n')
+                out_file.write(f'  val defaultVersion = "{new_version}"  // This is automatically bumped by the scala-libs release process, do not edit this line manually\n')
             else:
                 out_file.write(line)
 

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -54,8 +54,6 @@ if __name__ == '__main__':
     new_version = "v26.18.0"
 
     for repo in ("catalogue-api", "catalogue-pipeline", "storage-service"):
-        repo_dir = tempfile.mkdtemp()
-
         with cloned_repo(f"git@github.com:wellcomecollection/{repo}.git"):
             update_scala_libs_version(new_version)
 

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -53,7 +53,7 @@ def update_scala_libs_version(new_version):
 
 
 def get_github_api_key():
-    session = boto3.session()
+    session = boto3.Session()
     secrets_client = session.client("secretsmanager")
 
     secret_value = secrets_client.get_secret_value(SecretId="builds/github_wecobot/scala_libs_pr_bumps")

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
             branch_name = f"bump-scala-libs-to-{new_version}"
 
-            git("config", "--local", "user.email", "digital@wellcomecollection.org")
+            git("config", "--local", "user.email", "wellcomedigitalplatform@wellcome.ac.uk")
             git("config", "--local", "user.name", "BuildKite on behalf of Wellcome Collection")
 
             git("checkout", "-b", branch_name)

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
 
     pr_body = "\n".join([
         "Changelog entry:\n"
-    ] + ["> {line}" for line in changelog.splitlines()])
+    ] + [f"> {line}" for line in changelog.splitlines()])
 
     for repo in ("catalogue-api", "catalogue-pipeline", "storage-service"):
         with cloned_repo(f"git@github.com:wellcomecollection/{repo}.git"):
@@ -112,7 +112,7 @@ if __name__ == '__main__':
                 json={
                     "head": branch_name,
                     "base": "main",
-                    "title": "Bump scala-libs to {new_version}",
+                    "title": f"Bump scala-libs to {new_version}",
                     "maintainer_can_modify": True,
                     "body": pr_body,
                 }

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
             r = client.post(
                 f"https://api.github.com/repos/wellcomecollection/{repo}/pulls",
                 headers={"Accept": "application/vnd.github.v3+json"},
-                data={
+                json={
                     "head": branch_name,
                     "base": "main",
                     "title": "Bump scala-libs to {new_version}",

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import tempfile
 
+import boto3
+
 from commands import git
 
 
@@ -50,8 +52,20 @@ def update_scala_libs_version(new_version):
                 out_file.write(line)
 
 
+def get_github_api_key():
+    session = boto3.session()
+    secrets_client = session.client("secretsmanager")
+
+    secret_value = secrets_client.get_secret_value(SecretId="builds/github_wecobot/scala_libs_pr_bumps")
+
+    return secret_value["SecretString"]
+
+
 if __name__ == '__main__':
     new_version = "v26.18.0"
+
+    api_key = get_github_api_key()
+    print(api_key[:4])
 
     for repo in ("catalogue-api", "catalogue-pipeline", "storage-service"):
         with cloned_repo(f"git@github.com:wellcomecollection/{repo}.git"):

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -22,7 +22,7 @@ def working_directory(path):
         os.chdir(prev_cwd)
 
 
-@contextlib.contextlib
+@contextlib.contextmanager
 def cloned_repo(git_url):
     """
     Clones the repository and changes the working directory to the cloned

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -118,6 +118,8 @@ if __name__ == '__main__':
                 }
             )
 
+            print(r.json())
+
             r.raise_for_status()
 
         break

--- a/.buildkite/scripts/open_downstream_prs.py
+++ b/.buildkite/scripts/open_downstream_prs.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 
 import boto3
+import httpx
 
 from commands import git
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+A no-op change to trigger a release and test the auto-bumping.

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -77,8 +77,8 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
   }
 
   def withStringEntity[R](
-                           httpEntity: HttpEntity
-                         )(testWith: TestWith[String, R]): R =
+    httpEntity: HttpEntity
+  )(testWith: TestWith[String, R]): R =
     withMaterializer { implicit mat =>
       val value =
         httpEntity.dataBytes.runWith(Sink.fold("") {


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5200

This script runs at the end of a release build on main, in particular it:

* Clones the downstream repo
* Bumps the version in `Dependencies.scala`
* Commits that change and pushes it back to the repo
* Opens a PR for that change