### PR TITLE
convert index config to case class

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+RELEASE_TYPE: major
+
+### Libraries affected
+
+`elasticsearch`
+
+### Description
+
+Converts IndexConfig from an `object` to a `case class`
+
+This is to better reflect the way IndexConfig is used across the code base
+i.e. as immutable data structures.
+
+Add some creation ops from type config to IndexConfig.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ RELEASE_TYPE: major
 
 ### Description
 
-Converts IndexConfig from an `object` to a `case class`
+Converts IndexConfig from an `object` to a `case class`.
 
 This is to better reflect the way IndexConfig is used across the code base
 i.e. as immutable data structures.

--- a/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -22,14 +22,21 @@ object RefreshInterval {
   final case class On(duration: FiniteDuration) extends RefreshInterval
 }
 
-trait IndexConfig {
+trait IndexConfigTrait {
   def mapping: MappingDefinition
   def analysis: Analysis
   def shards: Int = 1
   def refreshInterval: RefreshInterval = RefreshInterval.Default
 }
 
-object NoStrictMapping extends IndexConfig {
+case class IndexConfig(mapping: MappingDefinition,
+                       analysis: Analysis,
+                       override val shards: Int = 1,
+                       override val refreshInterval: RefreshInterval =
+                         RefreshInterval.Default)
+    extends IndexConfigTrait
+
+object NoStrictMapping extends IndexConfigTrait {
   val analysis: Analysis = Analysis(analyzers = List())
   val mapping: MappingDefinition = MappingDefinition()
 }

--- a/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -37,7 +37,7 @@ object IndexConfig {
 
   implicit class IndexConfigOps(indexConfig: IndexConfig) {
     def withRefreshIntervalFromConfig(config: Config): IndexConfig = {
-      val isReindexing = config.getBoolean(s"es.is_reindexing")
+      val isReindexing = config.getBoolean("es.is_reindexing")
       val interval =
         if (isReindexing) RefreshInterval.Off else indexConfig.refreshInterval
 

--- a/elasticsearch/src/test/resources/reindexing.application.conf
+++ b/elasticsearch/src/test/resources/reindexing.application.conf
@@ -1,0 +1,1 @@
+es.is_reindexing=true

--- a/elasticsearch/src/test/resources/searching.application.conf
+++ b/elasticsearch/src/test/resources/searching.application.conf
@@ -1,0 +1,1 @@
+es.is_reindexing=false

--- a/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/IndexConfigTest.scala
+++ b/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/IndexConfigTest.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.elasticsearch
+
+import com.sksamuel.elastic4s.analysis.Analysis
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import org.scalatest.funspec.AnyFunSpec
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration.DurationInt
+
+class IndexConfigTest extends AnyFunSpec with Matchers {
+  val testConfig = IndexConfig(
+    analysis = Analysis(analyzers = List()),
+    mapping = MappingDefinition(),
+    refreshInterval = RefreshInterval.On(30.seconds)
+  )
+
+  it("sets the value of RefreshInterval to Off if es.is_reindexing is true") {
+    val config = ConfigFactory.load("reindexing.application")
+    val newIndexConfig: IndexConfig =
+      testConfig.withRefreshIntervalFromConfig(config)
+
+    newIndexConfig.refreshInterval shouldBe RefreshInterval.Off
+  }
+
+  it("maintains the value of RefreshInterval if es.is_reindexing is false") {
+    val config = ConfigFactory.load("searching.application")
+    val newIndexConfig: IndexConfig =
+      testConfig.withRefreshIntervalFromConfig(config)
+
+    newIndexConfig.refreshInterval shouldBe testConfig.refreshInterval
+  }
+}


### PR DESCRIPTION
Better reflects how we use it as a structure with varying values of immutable data.

Adds ops to create an `IndexConfig` from typesafe `Config`.

ref: https://github.com/wellcomecollection/catalogue-pipeline/issues/1694