### PR TITLE
Bump the default visibility timeout in the SQS fixtures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major
+
+The `withLocalSqsQueue` fixture now takes an instance of a Scala Duration instead of an Int, and increases the default timeout from 1 second to 5 seconds.

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -131,7 +131,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
       }
     )
 
-  def withLocalSqsQueuePair[R](visibilityTimeout: Int = 1)(
+  def withLocalSqsQueuePair[R](visibilityTimeout: Duration = 5.seconds)(
     testWith: TestWith[QueuePair, R]): R = {
     val queueName = createQueueName
 

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -116,7 +116,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
         setQueueAttribute(
           queueUrl = queue.url,
           attributeName = QueueAttributeName.VISIBILITY_TIMEOUT,
-          attributeValue = visibilityTimeout.toString
+          attributeValue = visibilityTimeout.toSeconds.toString
         )
 
         queue

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -16,6 +16,7 @@ import weco.monitoring.memory.MemoryMetrics
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 object SQS {
   case class Queue(url: String, arn: String, visibilityTimeout: Int) {
@@ -91,7 +92,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
   def withLocalSqsQueue[R](
     client: SqsClient = sqsClient,
     queueName: String = createQueueName,
-    visibilityTimeout: Int = 1
+    visibilityTimeout: Duration = 5.seconds
   ): Fixture[Queue, R] =
     fixture[Queue, R](
       create = {
@@ -109,7 +110,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
         val queue = Queue(
           url = response.queueUrl(),
           arn = arn,
-          visibilityTimeout = visibilityTimeout
+          visibilityTimeout = visibilityTimeout.toSeconds.toInt
         )
 
         setQueueAttribute(


### PR DESCRIPTION
It seems like 1 second is right on the cusp of being a bit too short for BuildKite, and a bunch of tests keep failing with flaky errors that look like SQS double-message sending.

Rather than bumping the timeout in individual tests, let's increase the default. I'm hoping this will stem the recent flakiness.