### PR TITLE
Allow setting global options in the AWSClientConfig builder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+Allow specifying global options for AWS client config, e.g. you can configure a default AWS region with
+
+```
+aws.region=${?aws_region
+```
+
+rather than having to specify it for every namespace/AWS service that you're using.

--- a/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
+++ b/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
@@ -2,19 +2,17 @@ package weco.typesafe.config.builders
 
 import com.typesafe.config.Config
 import weco.config.models.AWSClientConfig
-
 import EnrichConfig._
 
 trait AWSClientConfigBuilder {
   protected def buildAWSClientConfig(config: Config,
                                      namespace: String): AWSClientConfig = {
-    val accessKey = config.getStringOption(s"aws.$namespace.key")
-    val secretKey = config.getStringOption(s"aws.$namespace.secret")
-    val endpoint = config.getStringOption(s"aws.$namespace.endpoint")
-    val maxConnections =
-      config.getStringOption(s"aws.$namespace.max-connections")
+    val accessKey = config.getString("key", namespace = namespace)
+    val secretKey = config.getString("secret", namespace = namespace)
+    val endpoint = config.getString("endpoint", namespace = namespace)
+    val maxConnections = config.getString("max-connections", namespace = namespace)
     val region = config
-      .getStringOption(s"aws.$namespace.region")
+      .getString("region", namespace = namespace)
       .getOrElse("eu-west-1")
 
     AWSClientConfig(
@@ -24,5 +22,13 @@ trait AWSClientConfigBuilder {
       maxConnections = maxConnections,
       region = region
     )
+  }
+
+  implicit class AwsConfigOps(config: Config) {
+    def getString(key: String, namespace: String): Option[String] =
+      config.getStringOption(s"aws.$namespace.$key") match {
+        case Some(value) => Some(value)
+        case None        => config.getStringOption(s"aws.$key")
+      }
   }
 }

--- a/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
+++ b/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
@@ -7,12 +7,12 @@ import EnrichConfig._
 trait AWSClientConfigBuilder {
   protected def buildAWSClientConfig(config: Config,
                                      namespace: String): AWSClientConfig = {
-    val accessKey = config.getString("key", namespace = namespace)
-    val secretKey = config.getString("secret", namespace = namespace)
-    val endpoint = config.getString("endpoint", namespace = namespace)
-    val maxConnections = config.getString("max-connections", namespace = namespace)
+    val accessKey = config.getAwsString("key", namespace = namespace)
+    val secretKey = config.getAwsString("secret", namespace = namespace)
+    val endpoint = config.getAwsString("endpoint", namespace = namespace)
+    val maxConnections = config.getAwsString("max-connections", namespace = namespace)
     val region = config
-      .getString("region", namespace = namespace)
+      .getAwsString("region", namespace = namespace)
       .getOrElse("eu-west-1")
 
     AWSClientConfig(
@@ -25,7 +25,7 @@ trait AWSClientConfigBuilder {
   }
 
   implicit class AwsConfigOps(config: Config) {
-    def getString(key: String, namespace: String): Option[String] =
+    def getAwsString(key: String, namespace: String): Option[String] =
       config.getStringOption(s"aws.$namespace.$key") match {
         case Some(value) => Some(value)
         case None        => config.getStringOption(s"aws.$key")

--- a/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
+++ b/typesafe_app/src/main/scala/weco/typesafe/config/builders/AWSClientConfigBuilder.scala
@@ -10,7 +10,8 @@ trait AWSClientConfigBuilder {
     val accessKey = config.getAwsString("key", namespace = namespace)
     val secretKey = config.getAwsString("secret", namespace = namespace)
     val endpoint = config.getAwsString("endpoint", namespace = namespace)
-    val maxConnections = config.getAwsString("max-connections", namespace = namespace)
+    val maxConnections =
+      config.getAwsString("max-connections", namespace = namespace)
     val region = config
       .getAwsString("region", namespace = namespace)
       .getOrElse("eu-west-1")


### PR DESCRIPTION
Right now the storage service demo is failing because all our apps assume they're running in eu-west-1, but CUL are running in eu-west-1.

We do expose a config option for setting the AWS region in the Java SDK, but right now it's per-service client. This leads to rather unwieldy configurations like:

```
aws.ingest.sns.region=${?aws_region}
aws.metrics.region=${?aws_region}
aws.registration-notifications.sns.region=${?aws_region}
aws.sqs.region=${?aws_region}
```

This patch allows us to set a global AWS region that is used for all service clients, so config management is a bit simpler:

```
aws.region=${?aws_region}
```