### PR TITLE
Remove the use of `SqsClient` in favour of `SqsAsyncClient`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release removes all the use of `SqsClient`, because everywhere else in our projects we've switched exclusively to `SqsAsyncClient`.

--- a/messaging_typesafe/src/main/scala/weco/messaging/typesafe/SQSBuilder.scala
+++ b/messaging_typesafe/src/main/scala/weco/messaging/typesafe/SQSBuilder.scala
@@ -2,7 +2,7 @@ package weco.messaging.typesafe
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import software.amazon.awssdk.services.sqs.{SqsAsyncClient, SqsClient}
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import weco.messaging.sqs.{SQSConfig, SQSStream}
 import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.typesafe.config.builders.EnrichConfig._
@@ -22,9 +22,6 @@ object SQSBuilder {
       parallelism = parallelism
     )
   }
-
-  def buildSQSClient: SqsClient =
-    SqsClient.builder().build()
 
   def buildSQSAsyncClient: SqsAsyncClient =
     SqsAsyncClient.builder().build()


### PR DESCRIPTION
We only use the async client in our applications.  Having the configurable client is a holdover from when we'd sometimes use LocalStack SNS/SQS in our tests, but we no longer do that.  Remove the old clients so there's no confusion about what we should be using.

---

This is something I spotted while looking at https://github.com/wellcomecollection/scala-libs/pull/125

I found myself wondering why we have two flavours of SQS client, and it turns out we don't need one of them.