### PR TITLE
Fix a bug where partial locks weren't being released correctly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+Fix a bug in the LockingService where locks weren't being released correctly if there was a partial locking failure.
+
+e.g. if you tried to lock (A, B, C), successfully locked A and B but failed to lock C, then the locks for A and B wouldn't be released.
+Now they get released correctly.

--- a/storage/src/main/scala/weco/storage/locking/LockingService.scala
+++ b/storage/src/main/scala/weco/storage/locking/LockingService.scala
@@ -74,7 +74,6 @@ trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
     } else {
       lockDao.lock(ids.head, contextId) match {
         case Left(failure) =>
-
           // Remember to unlock any locks we've already acquired!  Otherwise retrying
           // this operation later is doomed to fail.
           unlock(contextId)

--- a/storage/src/main/scala/weco/storage/locking/LockingService.scala
+++ b/storage/src/main/scala/weco/storage/locking/LockingService.scala
@@ -74,6 +74,11 @@ trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
     } else {
       lockDao.lock(ids.head, contextId) match {
         case Left(failure) =>
+
+          // Remember to unlock any locks we've already acquired!  Otherwise retrying
+          // this operation later is doomed to fail.
+          unlock(contextId)
+
           Left(FailedLock(contextId, ids.tail.map(skipped) + failure))
         case Right(_) => getLocks(ids.tail, contextId)
       }

--- a/storage/src/test/scala/weco/storage/locking/LockingServiceTestCases.scala
+++ b/storage/src/test/scala/weco/storage/locking/LockingServiceTestCases.scala
@@ -25,7 +25,7 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
   val overlappingLockIds: Set[Ident] = commonLockIds ++ nonOverlappingLockIds
   val differentLockIds = Set(createIdent, createIdent, createIdent)
 
-  def withLockingService[R](testWith: TestWith[LockingServiceStub, R]): R =
+  def withLockingServiceImpl[R](testWith: TestWith[LockingServiceStub, R]): R =
     withLockDaoContext { lockDaoContext =>
       withLockDao(lockDaoContext) { lockDao =>
         withLockingService(lockDao) { service =>
@@ -106,7 +106,7 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
     }
 
     it("allows multiple, nested locks on different identifiers") {
-      withLockingService { service =>
+      withLockingServiceImpl { service =>
         assertLockSuccess(service.withLocks(lockIds) {
           assertLockSuccess(service.withLocks(differentLockIds)(f))
 
@@ -116,21 +116,21 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
     }
 
     it("unlocks a context set when done, and allows you to re-lock them") {
-      withLockingService { service =>
+      withLockingServiceImpl { service =>
         assertLockSuccess(service.withLocks(lockIds)(f))
         assertLockSuccess(service.withLocks(lockIds)(f))
       }
     }
 
     it("unlocks a context set when a result throws a Throwable") {
-      withLockingService { service =>
+      withLockingServiceImpl { service =>
         assertFailedProcess(service.withLocks(lockIds)(fError), expectedError)
         assertLockSuccess(service.withLocks(lockIds)(f))
       }
     }
 
     it("unlocks a context set when a partial lock is acquired") {
-      withLockingService { service =>
+      withLockingServiceImpl { service =>
         assertLockSuccess(service.withLocks(lockIds) {
 
           assertFailedLock(
@@ -149,7 +149,7 @@ trait LockingServiceTestCases[Ident, ContextId, LockDaoContext]
     }
 
     it("calls the callback if asked to lock an empty set") {
-      withLockingService { service =>
+      withLockingServiceImpl { service =>
         assertLockSuccess(
           service.withLocks(Set.empty)(f)
         )


### PR DESCRIPTION
e.g. if you tried to lock (A, B, C), successfully locked A and B but failed to lock C, then the locks for A and B wouldn't be released. Now they get released correctly.

I suspect this is the true culprit behind the bug I was chasing in https://github.com/wellcomecollection/platform/issues/5211

The immediate motivation for this is fixing an issue in the storage service where bags get "stuck" if you try to ingest multiple bags with the same ingest ID in quick succession, but I suspect it may also be causing us issues in the matcher that will be fixed by this patch.