### PR TITLE
Move TokenExchange back into the weco.http.client namespace

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Move TokenExchange back into the weco.http.client namespace.

--- a/http/src/main/scala/weco/http/client/TokenExchange.scala
+++ b/http/src/main/scala/weco/http/client/TokenExchange.scala
@@ -1,4 +1,4 @@
-package weco.sierra.http
+package weco.http.client
 
 import java.time.Instant
 import scala.concurrent.duration.Duration

--- a/http/src/test/scala/weco/http/client/TokenExchangeTest.scala
+++ b/http/src/test/scala/weco/http/client/TokenExchangeTest.scala
@@ -1,13 +1,13 @@
-package weco.sierra.http
+package weco.http.client
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
 
 class TokenExchangeTest extends AnyFunSpec with Matchers with ScalaFutures {

--- a/sierra/src/main/scala/weco/sierra/http/SierraOauthHttpClient.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraOauthHttpClient.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.headers.{
   OAuth2BearerToken
 }
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
-import weco.http.client.{HttpClient, HttpGet, HttpPost}
+import weco.http.client.{HttpClient, HttpGet, HttpPost, TokenExchange}
 import weco.http.json.CirceMarshalling
 
 import java.time.Instant


### PR DESCRIPTION
So we can use it in the METS adapter/transformer for the storage service
client.