### PR TITLE
Pull SierraSource from catalogue-api stacks library

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: minor
+
+### Libraries affected
+
+`sierra`
+
+### Description
+
+Adds SierraSource service for interacting with Sierra to retrieve and create holds.

--- a/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
@@ -1,0 +1,155 @@
+package weco.sierra.http
+
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import akka.stream.Materializer
+import io.circe.Encoder
+import weco.json.JsonUtil._
+import weco.http.json.CirceMarshalling
+import weco.sierra.models.data.SierraItemData
+import weco.sierra.models.identifiers.{SierraItemNumber, SierraPatronNumber}
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+
+import weco.http.client.{HttpClient, HttpGet, HttpPost}
+import weco.sierra.models.errors.{SierraErrorCode, SierraItemLookupError}
+import weco.sierra.models.fields.{SierraHoldRequest, SierraHoldsList, SierraItemDataEntries}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SierraSource(client: HttpClient with HttpGet with HttpPost)(
+  implicit
+  ec: ExecutionContext,
+  mat: Materializer
+) {
+  private implicit val umItemEntriesStub
+    : Unmarshaller[HttpEntity, SierraItemDataEntries] =
+    CirceMarshalling.fromDecoder[SierraItemDataEntries]
+
+  private implicit val umErrorCode: Unmarshaller[HttpEntity, SierraErrorCode] =
+    CirceMarshalling.fromDecoder[SierraErrorCode]
+
+  /** Returns data for a list of items
+    */
+  def lookupItemEntries(
+    itemNumbers: Seq[SierraItemNumber]
+  ): Future[Either[SierraItemLookupError, SierraItemDataEntries]] = {
+
+    val idList = itemNumbers
+      .map(_.withoutCheckDigit)
+      .mkString(",")
+
+    for {
+      response <- client.get(
+        path = Path("v5/items"),
+        params = Map(
+          "id" -> idList,
+          "fields" -> "deleted,fixedFields,holdCount,suppressed"
+        )
+      )
+
+      result <- response.status match {
+        case StatusCodes.OK =>
+          Unmarshal(response).to[SierraItemDataEntries].map { itemDataEntries =>
+            // There are a number of edge cases ignored here e.g.
+            // - there are more items returned than requested for this query
+            // - there are different items ids returned than requested for this query
+            // These cases are far less likely than requesting missing items which is
+            // dealt with here, so we ignore them for simplicity.
+            val foundItemNumbers = itemDataEntries.entries.map(_.id)
+
+            if (itemDataEntries.entries.size < itemNumbers.size) {
+              Left(
+                SierraItemLookupError.MissingItems(
+                  missingItems =
+                    itemNumbers.filterNot(foundItemNumbers.contains(_)),
+                  itemsReturned = itemDataEntries.entries
+                )
+              )
+            } else {
+              Right(itemDataEntries)
+            }
+          }
+
+        // When none of the item ids requested exist, sierra will 404
+        case StatusCodes.NotFound =>
+          Future.successful(
+            Left(
+              SierraItemLookupError.MissingItems(
+                missingItems = itemNumbers,
+                itemsReturned = Seq.empty
+              )
+            )
+          )
+
+        case _ =>
+          Unmarshal(response)
+            .to[SierraErrorCode]
+            .map(err => Left(SierraItemLookupError.UnknownError(err)))
+      }
+
+    } yield result
+  }
+
+  /** Returns data for a single item
+    */
+  def lookupItem(
+    item: SierraItemNumber
+  ): Future[Either[SierraItemLookupError, SierraItemData]] =
+    lookupItemEntries(Seq(item)).map {
+      case Right(itemDataEntries) =>
+        Right(itemDataEntries.entries.head)
+      case Left(SierraItemLookupError.MissingItems(_, _)) =>
+        Left(SierraItemLookupError.ItemNotFound)
+      case Left(value) => Left(value)
+    }
+
+  private implicit val umHoldsList: Unmarshaller[HttpEntity, SierraHoldsList] =
+    CirceMarshalling.fromDecoder[SierraHoldsList]
+
+  /** Returns a list of holds for this user.
+    *
+    * Note: do not rely on this method to prove the existence of a user.
+    * In particular, the Sierra API will return an empty list of holds if you
+    * query this API for a patron ID that doesn't exist.
+    *
+    */
+  def listHolds(
+    patron: SierraPatronNumber
+  ): Future[Either[SierraErrorCode, SierraHoldsList]] =
+    for {
+      resp <- client.get(
+        path = Path(s"v5/patrons/${patron.withoutCheckDigit}/holds"),
+        params = Map("limit" -> "100", "offset" -> "0")
+      )
+
+      result <- resp.status match {
+        case StatusCodes.OK => Unmarshal(resp).to[SierraHoldsList].map(Right(_))
+        case _              => Unmarshal(resp).to[SierraErrorCode].map(Left(_))
+      }
+    } yield result
+
+  private val dateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd")
+    .withZone(ZoneId.systemDefault())
+
+  implicit val encodeInstant: Encoder[Instant] =
+    Encoder.encodeString.contramap[Instant](dateTimeFormatter.format)
+
+  def createHold(
+    patron: SierraPatronNumber,
+    item: SierraItemNumber
+  ): Future[Either[SierraErrorCode, Unit]] =
+    for {
+      resp <- client.post(
+        path = Path(s"v5/patrons/${patron.withoutCheckDigit}/holds/requests"),
+        body = Some(SierraHoldRequest(item))
+      )
+
+      result <- resp.status match {
+        case StatusCodes.NoContent => Future.successful(Right(()))
+        case _                     => Unmarshal(resp).to[SierraErrorCode].map(Left(_))
+      }
+    } yield result
+}

--- a/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
@@ -14,7 +14,11 @@ import java.time.format.DateTimeFormatter
 
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 import weco.sierra.models.errors.{SierraErrorCode, SierraItemLookupError}
-import weco.sierra.models.fields.{SierraHoldRequest, SierraHoldsList, SierraItemDataEntries}
+import weco.sierra.models.fields.{
+  SierraHoldRequest,
+  SierraHoldsList,
+  SierraItemDataEntries
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/sierra/src/main/scala/weco/sierra/models/errors/SierraErrorCode.scala
+++ b/sierra/src/main/scala/weco/sierra/models/errors/SierraErrorCode.scala
@@ -1,0 +1,9 @@
+package weco.sierra.models.errors
+
+case class SierraErrorCode(
+  code: Int,
+  specificCode: Int,
+  httpStatus: Int,
+  name: String,
+  description: Option[String] = None
+)

--- a/sierra/src/main/scala/weco/sierra/models/errors/SierraItemLookupError.scala
+++ b/sierra/src/main/scala/weco/sierra/models/errors/SierraItemLookupError.scala
@@ -1,0 +1,18 @@
+package weco.sierra.models.errors
+
+import weco.sierra.models.data.SierraItemData
+import weco.sierra.models.identifiers.SierraItemNumber
+
+sealed trait SierraItemLookupError
+
+object SierraItemLookupError {
+  case object ItemNotFound extends SierraItemLookupError
+
+  case class MissingItems(
+    missingItems: Seq[SierraItemNumber],
+    itemsReturned: Seq[SierraItemData]
+  ) extends SierraItemLookupError
+
+  case class UnknownError(errorCode: SierraErrorCode)
+      extends SierraItemLookupError
+}

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraHold.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraHold.scala
@@ -1,0 +1,20 @@
+package weco.sierra.models.fields
+
+import java.net.URI
+import java.time.Instant
+
+// This represents a Sierra Hold object, as described in the Sierra docs:
+// https://techdocs.iii.com/sierraapi/Content/zReference/objects/holdObjectDescription.htm
+
+case class SierraHoldStatus(
+  code: String,
+  name: String
+)
+
+case class SierraHold(
+  id: URI,
+  record: URI,
+  pickupLocation: SierraLocation,
+  pickupByDate: Option[Instant],
+  status: SierraHoldStatus
+)

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldRequest.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldRequest.scala
@@ -1,0 +1,20 @@
+package weco.sierra.models.fields
+
+import weco.sierra.models.identifiers.SierraItemNumber
+
+case class SierraHoldRequest(
+  recordType: String,
+  recordNumber: Long,
+  pickupLocation: String
+)
+
+case object SierraHoldRequest {
+  def apply(item: SierraItemNumber): SierraHoldRequest =
+    SierraHoldRequest(
+      recordType = "i",
+      recordNumber = item.withoutCheckDigit.toLong,
+      // This field is required non-empty by the Sierra API
+      // but seems to have no effect
+      pickupLocation = "unspecified"
+    )
+}

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldsList.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldsList.scala
@@ -1,0 +1,6 @@
+package weco.sierra.models.fields
+
+case class SierraHoldsList(
+  total: Long,
+  entries: List[SierraHold]
+)

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraItemDataEntries.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraItemDataEntries.scala
@@ -1,0 +1,9 @@
+package weco.sierra.models.fields
+
+import weco.sierra.models.data.SierraItemData
+
+case class SierraItemDataEntries(
+                                  total: Int,
+                                  start: Int,
+                                  entries: Seq[SierraItemData]
+                                )

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraItemDataEntries.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraItemDataEntries.scala
@@ -3,7 +3,7 @@ package weco.sierra.models.fields
 import weco.sierra.models.data.SierraItemData
 
 case class SierraItemDataEntries(
-                                  total: Int,
-                                  start: Int,
-                                  entries: Seq[SierraItemData]
-                                )
+  total: Int,
+  start: Int,
+  entries: Seq[SierraItemData]
+)

--- a/sierra/src/test/scala/weco/sierra/fixtures/SierraSourceFixture.scala
+++ b/sierra/src/test/scala/weco/sierra/fixtures/SierraSourceFixture.scala
@@ -1,0 +1,24 @@
+package weco.sierra.fixtures
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import weco.akka.fixtures.Akka
+import weco.fixtures.TestWith
+import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
+import weco.http.fixtures.HttpFixtures
+import weco.sierra.http.SierraSource
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait SierraSourceFixture extends HttpFixtures with Akka {
+  def withSierraSource[R](
+                           responses: Seq[(HttpRequest, HttpResponse)] = Seq()
+                         )(testWith: TestWith[SierraSource, R]): R =
+    withMaterializer { implicit mat =>
+      val httpClient = new MemoryHttpClient(responses) with HttpGet
+        with HttpPost {
+        override val baseUri: Uri = Uri("http://sierra:1234")
+      }
+
+      testWith(new SierraSource(httpClient))
+    }
+}

--- a/sierra/src/test/scala/weco/sierra/http/SierraSourceTest.scala
+++ b/sierra/src/test/scala/weco/sierra/http/SierraSourceTest.scala
@@ -1,0 +1,610 @@
+package weco.sierra.http
+
+import akka.http.scaladsl.model._
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.akka.fixtures.Akka
+import weco.fixtures.TestWith
+import weco.sierra.models.fields.{SierraHold, SierraHoldStatus, SierraHoldsList, SierraItemDataEntries, SierraLocation}
+import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
+import weco.sierra.models.data.SierraItemData
+import weco.sierra.models.identifiers.{SierraItemNumber, SierraPatronNumber}
+import java.net.URI
+
+import weco.sierra.models.errors.{SierraErrorCode, SierraItemLookupError}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SierraSourceTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with Akka
+    with ScalaFutures
+    with IntegrationPatience {
+  def withSource[R](
+    responses: Seq[(HttpRequest, HttpResponse)]
+  )(testWith: TestWith[SierraSource, R]): R =
+    withMaterializer { implicit mat =>
+      val client =
+        new MemoryHttpClient(responses = responses) with HttpGet with HttpPost {
+          override val baseUri: Uri = Uri("http://sierra:1234")
+        }
+
+      val source = new SierraSource(client)
+
+      testWith(source)
+    }
+
+  describe("lookupItemEntries") {
+    it("looks up multiple items") {
+      val itemNumbers = List(
+        SierraItemNumber("1146055"),
+        SierraItemNumber("1234567")
+      )
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1146055,1234567&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "total": 2,
+                |  "start": 0,
+                |  "entries": [
+                |    {
+                |      "id": "1146055",
+                |      "deleted": false,
+                |      "suppressed": false,
+                |      "holdCount": 0,
+                |      "location": {
+                |        "code": "sgmed",
+                |        "name": "Closed stores Med."
+                |      }
+                |    },
+                |    {
+                |      "id": "1234567",
+                |      "deleted": false,
+                |      "suppressed": false,
+                |      "holdCount": 0,
+                |      "location": {
+                |        "code": "sgmed",
+                |        "name": "Closed stores Med."
+                |      }
+                |    }
+                |  ]
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItemEntries(itemNumbers)
+
+        whenReady(future) {
+          _ shouldBe Right(
+            SierraItemDataEntries(
+              total = 2,
+              start = 0,
+              entries = Seq(
+                SierraItemData(
+                  id = SierraItemNumber("1146055"),
+                  deleted = false,
+                  location = Some(
+                    SierraLocation(
+                      code = "sgmed",
+                      name = "Closed stores Med."
+                    )
+                  )
+                ),
+                SierraItemData(
+                  id = SierraItemNumber("1234567"),
+                  deleted = false,
+                  location = Some(
+                    SierraLocation(
+                      code = "sgmed",
+                      name = "Closed stores Med."
+                    )
+                  )
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    it("looks up multiple items where some do not exist") {
+      val missingItemNumber = SierraItemNumber("1234567")
+      val itemNumbers = List(
+        SierraItemNumber("1146055"),
+        missingItemNumber
+      )
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1146055,1234567&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "total": 1,
+                |  "start": 0,
+                |  "entries": [
+                |    {
+                |      "id": "1146055",
+                |      "deleted": false,
+                |      "suppressed": false,
+                |      "holdCount": 0,
+                |      "location": {
+                |        "code": "sgmed",
+                |        "name": "Closed stores Med."
+                |      }
+                |    }
+                |  ]
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItemEntries(itemNumbers)
+
+        whenReady(future) {
+          _ shouldBe Left(
+            SierraItemLookupError.MissingItems(
+              missingItems = Seq(missingItemNumber),
+              itemsReturned = Seq(
+                SierraItemData(
+                  id = SierraItemNumber("1146055"),
+                  deleted = false,
+                  location = Some(
+                    SierraLocation(
+                      code = "sgmed",
+                      name = "Closed stores Med."
+                    )
+                  )
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    it("looks up multiple items where none exist") {
+      val itemNumbers = List(
+        SierraItemNumber("1146055"),
+        SierraItemNumber("1234567")
+      )
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1146055,1234567&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            status = StatusCodes.NotFound,
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "code": 107,
+                |  "specificCode": 0,
+                |  "httpStatus": 404,
+                |  "name": "Record not found"
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItemEntries(itemNumbers)
+
+        whenReady(future) {
+          _ shouldBe Left(
+            SierraItemLookupError.MissingItems(
+              missingItems = itemNumbers,
+              itemsReturned = Seq.empty
+            )
+          )
+        }
+      }
+    }
+  }
+
+  describe("lookupItem") {
+    it("looks up a single item") {
+      val itemNumber = SierraItemNumber("1146055")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1146055&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "total": 1,
+                |  "start": 0,
+                |  "entries": [
+                |    {
+                |      "id": "1146055",
+                |      "updatedDate": "2021-06-09T13:23:27Z",
+                |      "createdDate": "1999-11-15T18:56:00Z",
+                |      "deleted": false,
+                |      "bibIds": [
+                |        "1126829"
+                |      ],
+                |      "location": {
+                |        "code": "sgmed",
+                |        "name": "Closed stores Med."
+                |      },
+                |      "status": {
+                |        "code": "t",
+                |        "display": "In quarantine"
+                |      },
+                |      "volumes": [],
+                |      "barcode": "22500271327",
+                |      "callNumber": "K33043"
+                |    }
+                |  ]
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItem(itemNumber)
+
+        whenReady(future) {
+          _ shouldBe Right(
+            SierraItemData(
+              id = itemNumber,
+              deleted = false,
+              location = Some(
+                SierraLocation(
+                  code = "sgmed",
+                  name = "Closed stores Med."
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+
+    it("looks up a non-existent item") {
+      val itemNumber = SierraItemNumber("1000000")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1000000&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            status = StatusCodes.NotFound,
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "code": 107,
+                |  "specificCode": 0,
+                |  "httpStatus": 404,
+                |  "name": "Record not found"
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItem(itemNumber)
+
+        whenReady(future) {
+          _ shouldBe Left(SierraItemLookupError.ItemNotFound)
+        }
+      }
+    }
+
+    it("looks up a deleted item") {
+      val itemNumber = SierraItemNumber("1000001")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              "http://sierra:1234/v5/items?id=1000001&fields=deleted,fixedFields,holdCount,suppressed"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "total": 1,
+                |  "start": 0,
+                |  "entries": [
+                |    {
+                |      "id": "1000001",
+                |      "deletedDate": "2004-04-14",
+                |      "deleted": true,
+                |      "bibIds": [],
+                |      "volumes": []
+                |    }
+                |  ]
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItem(itemNumber)
+
+        whenReady(future) {
+          _.value shouldBe SierraItemData(id = itemNumber, deleted = true)
+        }
+      }
+    }
+  }
+
+  describe("listHolds") {
+    it("looks up the holds for a user") {
+      val patron = SierraPatronNumber("1234567")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              s"http://sierra:1234/v5/patrons/${patron.withoutCheckDigit}/holds?limit=100&offset=0"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              s"""
+                |{
+                |  "total": 2,
+                |  "start": 0,
+                |  "entries": [
+                |    {
+                |      "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/1111",
+                |      "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/1111111",
+                |      "patron": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/${patron.withoutCheckDigit}",
+                |      "frozen": false,
+                |      "placed": "2021-05-07",
+                |      "notWantedBeforeDate": "2021-05-07",
+                |      "pickupLocation": {
+                |        "code": "sotop",
+                |        "name": "Rare Materials Room"
+                |      },
+                |      "status": {
+                |        "code": "0",
+                |        "name": "on hold."
+                |      },
+                |      "recordType": "i",
+                |      "priority": 1
+                |    },
+                |    {
+                |      "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/2222",
+                |      "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/2222222",
+                |      "patron": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/${patron.withoutCheckDigit}",
+                |      "frozen": false,
+                |      "placed": "2021-05-11",
+                |      "notWantedBeforeDate": "2021-05-11",
+                |      "pickupLocation": {
+                |        "code": "hgser",
+                |        "name": "Library Enquiry Desk"
+                |      },
+                |      "status": {
+                |        "code": "i",
+                |        "name": "item hold ready for pickup."
+                |      },
+                |      "recordType": "i",
+                |      "priority": 1
+                |    }
+                |  ]
+                |}
+                |
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.listHolds(patron)
+
+        whenReady(future) {
+          _.value shouldBe
+            SierraHoldsList(
+              total = 2,
+              entries = List(
+                SierraHold(
+                  id = new URI(
+                    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/1111"
+                  ),
+                  record = new URI(
+                    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/1111111"
+                  ),
+                  pickupLocation = SierraLocation(
+                    code = "sotop",
+                    name = "Rare Materials Room"
+                  ),
+                  pickupByDate = None,
+                  status = SierraHoldStatus(code = "0", name = "on hold.")
+                ),
+                SierraHold(
+                  id = new URI(
+                    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/2222"
+                  ),
+                  record = new URI(
+                    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/2222222"
+                  ),
+                  pickupLocation = SierraLocation(
+                    code = "hgser",
+                    name = "Library Enquiry Desk"
+                  ),
+                  pickupByDate = None,
+                  status = SierraHoldStatus(
+                    code = "i",
+                    name = "item hold ready for pickup."
+                  )
+                )
+              )
+            )
+        }
+      }
+    }
+
+    it("looks up an empty list of holds") {
+      val patron = SierraPatronNumber("1234567")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri(
+              s"http://sierra:1234/v5/patrons/${patron.withoutCheckDigit}/holds?limit=100&offset=0"
+            )
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              s"""
+                 |{
+                 |  "total": 0,
+                 |  "start": 0,
+                 |  "entries": []
+                 |}
+                 |
+                 |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.listHolds(patron)
+
+        whenReady(future) {
+          _.value shouldBe SierraHoldsList(total = 0, entries = List())
+        }
+      }
+    }
+  }
+
+  describe("createHold") {
+    it("creates a hold") {
+      val patron = SierraPatronNumber("1234567")
+      val item = SierraItemNumber("1111111")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            method = HttpMethods.POST,
+            uri = Uri(
+              s"http://sierra:1234/v5/patrons/${patron.withoutCheckDigit}/holds/requests"
+            ),
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              s"""{"recordType":"i","recordNumber":${item.withoutCheckDigit},"pickupLocation":"unspecified"}"""
+            )
+          ),
+          HttpResponse(
+            status = StatusCodes.NoContent,
+            entity = HttpEntity.Empty
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.createHold(patron, item)
+
+        whenReady(future) {
+          _.value shouldBe (())
+        }
+      }
+    }
+
+    it("returns an error if the hold can't be placed") {
+      val patron = SierraPatronNumber("1234567")
+      val item = SierraItemNumber("1111111")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            method = HttpMethods.POST,
+            uri = Uri(
+              s"http://sierra:1234/v5/patrons/${patron.withoutCheckDigit}/holds/requests"
+            ),
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              s"""{"recordType":"i","recordNumber":${item.withoutCheckDigit},"pickupLocation":"unspecified"}"""
+            )
+          ),
+          HttpResponse(
+            status = StatusCodes.InternalServerError,
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "code": 132,
+                |  "specificCode": 2,
+                |  "httpStatus": 500,
+                |  "name": "XCirc error",
+                |  "description": "XCirc error : This record is not available"
+                |}
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.createHold(patron, item)
+
+        whenReady(future) {
+          _.left.value shouldBe SierraErrorCode(
+            code = 132,
+            specificCode = 2,
+            httpStatus = 500,
+            name = "XCirc error",
+            description = Some("XCirc error : This record is not available")
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change adds all the Sierra specific logic & models from the catalogue-api stacks library to reduce the common-lib in that project and keep same-domain code together.