### PR TITLE
Inspect queue size based on metrics, not waiting for messages to appear

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This changes the way we inspect queue sizes in the SQS fixture: rather than waiting for the visibility timeout to expire, we inspect the queue metrics for all messages (visible, in-flight, delayed), and compare those to the expected size.
+
+This should make all tests using `assertQueueSize` or `assertQueueEmpty` both more accurate and a lot faster.

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -166,15 +166,12 @@ trait SQS extends Matchers with Logging with RandomGenerators {
     testWith(stream)
   }
 
-  def createNotificationMessageWith(body: String): NotificationMessage =
-    NotificationMessage(body = body)
-
   def createNotificationMessageWith[T](message: T)(
     implicit encoder: Encoder[T]): NotificationMessage =
-    createNotificationMessageWith(body = toJson(message).get)
+    NotificationMessage(body = toJson(message).get)
 
   def sendNotificationToSQS(queue: Queue, body: String): SendMessageResponse = {
-    val message = createNotificationMessageWith(body = body)
+    val message = NotificationMessage(body = body)
 
     sendSqsMessage(queue = queue, obj = message)
   }

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -79,11 +79,6 @@ trait SQS extends Matchers with Logging with RandomGenerators {
       .toMap
   }
 
-  private def getQueueAttribute(
-    queue: Queue,
-    attributeName: QueueAttributeName): String =
-    getQueueAttributes(queue.url, attributeName)(attributeName)
-
   def createQueueName: String =
     randomAlphanumeric()
 

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -62,25 +62,27 @@ trait SQS extends Matchers with Logging with RandomGenerators {
       }
       .get()
 
-  private def getQueueAttribute(queueUrl: String,
-                                attributeName: QueueAttributeName): String =
-    asyncSqsClient
-      .getQueueAttributes { builder: GetQueueAttributesRequest.Builder =>
-        builder
-          .queueUrl(queueUrl)
-          .attributeNames(attributeName)
-      }
-      .get()
-      .attributes()
-      .get(attributeName)
+  private def getQueueAttributes(queueUrl: String,
+                                 attributeNames: QueueAttributeName*): Map[QueueAttributeName, String] = {
+    val attributeValues =
+      asyncSqsClient
+        .getQueueAttributes { builder: GetQueueAttributesRequest.Builder =>
+          builder
+            .queueUrl(queueUrl)
+            .attributeNames(attributeNames: _*)
+        }
+        .get()
+        .attributes()
 
-  def getQueueAttribute(
+    attributeNames
+      .map { name => name -> attributeValues.get(name)}
+      .toMap
+  }
+
+  private def getQueueAttribute(
     queue: Queue,
     attributeName: QueueAttributeName): String =
-    getQueueAttribute(
-      queueUrl = queue.url,
-      attributeName = attributeName
-    )
+    getQueueAttributes(queue.url, attributeName)(attributeName)
 
   def createQueueName: String =
     randomAlphanumeric()
@@ -98,10 +100,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
           }
           .get()
 
-        val arn = getQueueAttribute(
-          queueUrl = response.queueUrl(),
-          attributeName = QueueAttributeName.QUEUE_ARN
-        )
+        val arn = getQueueAttributes(response.queueUrl(), QueueAttributeName.QUEUE_ARN)(QueueAttributeName.QUEUE_ARN)
 
         val queue = Queue(
           url = response.queueUrl(),
@@ -204,58 +203,49 @@ trait SQS extends Matchers with Logging with RandomGenerators {
       .get
   }
 
-  def noMessagesAreWaitingIn(queue: Queue): Assertion = {
-    val messagesInFlight = getQueueAttribute(
-      queue,
-      attributeName =
-        QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE
+  /** Returns a rough count of all the messages on a queue. */
+  private def countMessagesOnQueue(queue: Queue): Map[QueueAttributeName, Int] = {
+    val attributeNames = Seq(
+      // Messages available for retrieval
+      QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES,
+
+      // Messages in the queue and not available for reading immediately
+      QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_DELAYED,
+
+      // Messages currently in flight
+      QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE,
     )
 
-    assert(
-      messagesInFlight == "0",
-      s"Expected messages in flight on ${queue.url} to be 0, actually $messagesInFlight"
-    )
-
-    val messagesWaiting = getQueueAttribute(
-      queue,
-      attributeName = QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES
-    )
-
-    assert(
-      messagesWaiting == "0",
-      s"Expected messages waiting on ${queue.url} to be 0, actually $messagesWaiting"
-    )
+    getQueueAttributes(queue.url, attributeNames: _*)
+      .map { case (name, count) => name -> count.toInt }
   }
 
-  def assertQueueEmpty(queue: Queue): Assertion = {
-    waitVisibilityTimeoutExpiry(queue)
-
-    val messages = getMessages(queue)
-
-    assert(
-      messages.isEmpty,
-      s"Expected not to get any messages from ${queue.url}, actually got $messages")
-
-    noMessagesAreWaitingIn(queue)
+  def assertQueueEmpty(queue: Queue): Unit = {
+    countMessagesOnQueue(queue).foreach { case (name, count) =>
+      assert(
+        count == 0,
+        s"Expected ${queue.url} to have $name == 0, got $name == $count"
+      )
+    }
   }
 
   def assertQueueHasSize(queue: Queue, size: Int): Assertion = {
-    waitVisibilityTimeoutExpiry(queue)
-
-    val messages = getMessages(queue)
-    val messagesSize = messages.size
+    val counts = countMessagesOnQueue(queue)
 
     assert(
-      messagesSize == size,
-      s"Expected queue ${queue.url} to have size $size, actually had size $messagesSize"
+      counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES) == size,
+      s"Expected queue ${queue.url} to have $size messages available, actually has ${counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES)}"
     )
-  }
 
-  private def waitVisibilityTimeoutExpiry(queue: Queue): Unit = {
-    // Wait slightly longer than the visibility timeout to ensure that messages
-    // that fail processing become visible again before asserting.
-    val millisecondsToWait = (queue.visibilityTimeout.toMillis * 1.5).toInt
-    Thread.sleep(millisecondsToWait)
+    assert(
+      counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_DELAYED) == 0,
+      s"Expected queue ${queue.url} to have $size messages delayed, actually has ${counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES)}"
+    )
+
+    assert(
+      counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) == 0,
+      s"Expected queue ${queue.url} to have $size messages in flight, actually has ${counts(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES)}"
+    )
   }
 
   def getMessages(queue: Queue): Seq[Message] =


### PR DESCRIPTION
You might have noticed that any test that relies on an SQS queue has gotten a lot slower recently – like, 30 seconds per test slower. That's because when you call `assertQueueSize`, we were waiting for 1.5x the queue visibility timeout to elapse before doing anything. This delay was mostly tolerable when the default timeout was 1s (wait 3s to inspect a queue and its DLQ), but I recently upped that timeout to 5s to avoid flaky tests in CI. So if you inspect two queues, you went from a 3 second to a 15 second wait. Oof.

This patch refactors the SQS queue fixture to avoid that delay, which should make all our tests much faster.

Thing is, waiting for visibility timeout to elapse isn't ideal. The theory went: _"I want to know how many messages are on a queue. I should wait for the visibility timeout to expire, then fetch from the queue and see what I get."_ This is fine… if you're the only person reading from the queue. But in all the tests where we create mock queues, we've got a worker that's also reading from the queue.

So we could wait for this timeout, fetch from the queue, and see the wrong size… because the worker got there before us. So we're already inspecting the MESSAGES_IN_FLIGHT metric to see if somebody else has some messages. This patch updates us to _only_ look at that metric, which is the most sensible way to assess queue size.

Plus some general tweaking around how we look up queue attributes, and making a few low-level methods private to encourage downstream code towards the helper methods.