### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# To ensure only properly audited changes are run in CI, we require reviews
+# from @wellcomecollection/buildkite-admin when updating pipeline config
+
+/.buildkite/    @wellcomecollection/buildkite-admin


### PR DESCRIPTION
In order to ensure that changes to code run in the CI environment are properly reviewed, this change enforces that members of the @wellcomecollection/buildkite-admin group must approve changes to code run during in CI.

This is in conjunction with adding branch protection rules to main in the repo configuration.