### PR TITLE
Improve the error messages used with StorageError

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+All instances of StorageError now include a custom exception message.
+This should be easier to debug than seeing `java.lang.Error: null` in the logs.

--- a/storage/src/main/scala/weco/storage/StorageError.scala
+++ b/storage/src/main/scala/weco/storage/StorageError.scala
@@ -39,7 +39,7 @@ case class StoreWriteError(e: Throwable) extends WriteError with BackendError
 
 case class OverwriteError(e: Throwable) extends WriteError with BackendError
 
-case class IncorrectStreamLengthError(e: Throwable = new Error())
+case class IncorrectStreamLengthError(e: Throwable)
     extends DecoderError
     with EncoderError
 
@@ -49,33 +49,29 @@ sealed trait ReadError extends StorageError
 sealed trait NotFoundError extends ReadError
 sealed trait VersionError extends StorageError
 
-case class NoVersionExistsError(e: Throwable = new Error())
+case class NoVersionExistsError(message: String)
     extends VersionError
-    with NotFoundError
-case class HigherVersionExistsError(e: Throwable = new Error())
+    with NotFoundError {
+  val e: Throwable = new Throwable(message)
+}
+
+case class HigherVersionExistsError(message: String)
     extends VersionError
-    with WriteError
-case class VersionAlreadyExistsError(e: Throwable = new Error())
+    with WriteError {
+  val e: Throwable = new Throwable(message)
+}
+
+case class VersionAlreadyExistsError(message: String)
     extends VersionError
-    with WriteError
+    with WriteError {
+  val e: Throwable = new Throwable(message)
+}
 
-sealed trait DecoderError extends ReadError
-
-case class MetadataCoercionFailure(
-  failure: List[CodecError],
-  success: List[(String, String)],
-  e: Throwable = new Error()
-) extends WriteError
-
-case class InvalidIdentifierFailure(e: Throwable = new Error())
+case class InvalidIdentifierFailure(e: Throwable)
     extends WriteError
 
-case class DoesNotExistError(e: Throwable = new Error())
+case class DoesNotExistError(e: Throwable)
     extends NotFoundError
-    with BackendError
-
-case class MultipleRecordsError(e: Throwable = new Error())
-    extends ReadError
     with BackendError
 
 case class StoreReadError(e: Throwable) extends ReadError with BackendError
@@ -84,9 +80,7 @@ case class DanglingHybridStorePointerError(e: Throwable) extends ReadError
 
 case class CannotCloseStreamError(e: Throwable) extends ReadError
 
-case class CharsetDecodingError(e: Throwable = new Error())
-    extends CodecError
-    with DecoderError
+sealed trait DecoderError extends ReadError
 
 case class ByteDecodingError(e: Throwable) extends DecoderError
 
@@ -96,13 +90,12 @@ case class JsonDecodingError(e: Throwable) extends DecoderError
 
 sealed trait MaximaError extends ReadError with BackendError
 
-case class MaximaReadError(e: Throwable = new Error())
+case class MaximaReadError(e: Throwable)
     extends MaximaError
     with StorageError
-case class NoMaximaValueError(e: Throwable = new Error())
+case class NoMaximaValueError(e: Throwable)
     extends MaximaError
     with StorageError
 
-case class ListingFailure[SrcLocation](source: SrcLocation,
-                                       e: Throwable = new Error())
+case class ListingFailure[SrcLocation](source: SrcLocation, e: Throwable)
     extends ReadError

--- a/storage/src/main/scala/weco/storage/StorageError.scala
+++ b/storage/src/main/scala/weco/storage/StorageError.scala
@@ -67,8 +67,7 @@ case class VersionAlreadyExistsError(message: String)
   val e: Throwable = new Throwable(message)
 }
 
-case class InvalidIdentifierFailure(e: Throwable)
-    extends WriteError
+case class InvalidIdentifierFailure(e: Throwable) extends WriteError
 
 case class DoesNotExistError(e: Throwable)
     extends NotFoundError
@@ -90,9 +89,7 @@ case class JsonDecodingError(e: Throwable) extends DecoderError
 
 sealed trait MaximaError extends ReadError with BackendError
 
-case class MaximaReadError(e: Throwable)
-    extends MaximaError
-    with StorageError
+case class MaximaReadError(e: Throwable) extends MaximaError with StorageError
 case class NoMaximaValueError(e: Throwable)
     extends MaximaError
     with StorageError

--- a/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
+++ b/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
@@ -33,7 +33,9 @@ trait DynamoHashRangeMaxima[HashKey, RangeKey, T]
       case Success(List(Left(err))) =>
         val error = new Error(s"DynamoReadError: ${err.toString}")
         Left(MaximaReadError(error))
-      case Success(Nil) => Left(NoMaximaValueError())
+      case Success(Nil) =>
+        val error = new Error(s"There are no Dynamo items with hash key id=$hashKey")
+        Left(NoMaximaValueError(error))
       case Failure(err) => Left(MaximaReadError(err))
 
       // This case should be impossible to hit in practice -- limit(1)

--- a/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
+++ b/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
@@ -34,7 +34,8 @@ trait DynamoHashRangeMaxima[HashKey, RangeKey, T]
         val error = new Error(s"DynamoReadError: ${err.toString}")
         Left(MaximaReadError(error))
       case Success(Nil) =>
-        val error = new Error(s"There are no Dynamo items with hash key id=$hashKey")
+        val error = new Error(
+          s"There are no Dynamo items with hash key id=$hashKey")
         Left(NoMaximaValueError(error))
       case Failure(err) => Left(MaximaReadError(err))
 

--- a/storage/src/main/scala/weco/storage/maxima/memory/MemoryMaxima.scala
+++ b/storage/src/main/scala/weco/storage/maxima/memory/MemoryMaxima.scala
@@ -14,7 +14,8 @@ trait MemoryMaxima[Id, T]
         .filter { case (ident, _) => ident.id == id }
 
     if (matchingEntries.isEmpty) {
-      Left(NoMaximaValueError())
+      val error = new Throwable(s"Could not find maxima for id=$id")
+      Left(NoMaximaValueError(error))
     } else {
       val (maxIdent, maxT) =
         matchingEntries.maxBy { case (ident, _) => ident.version }

--- a/storage/src/main/scala/weco/storage/services/memory/MemorySizeFinder.scala
+++ b/storage/src/main/scala/weco/storage/services/memory/MemorySizeFinder.scala
@@ -10,6 +10,7 @@ class MemorySizeFinder[Ident](
   override def get(id: Ident): ReadEither =
     memoryStore.entries.get(id) match {
       case Some(entry) => Right(Identified(id, entry.length))
-      case None        => Left(DoesNotExistError(new Throwable(s"There is no entry for id=$id")))
+      case None =>
+        Left(DoesNotExistError(new Throwable(s"There is no entry for id=$id")))
     }
 }

--- a/storage/src/main/scala/weco/storage/services/memory/MemorySizeFinder.scala
+++ b/storage/src/main/scala/weco/storage/services/memory/MemorySizeFinder.scala
@@ -10,6 +10,6 @@ class MemorySizeFinder[Ident](
   override def get(id: Ident): ReadEither =
     memoryStore.entries.get(id) match {
       case Some(entry) => Right(Identified(id, entry.length))
-      case None        => Left(DoesNotExistError())
+      case None        => Left(DoesNotExistError(new Throwable(s"There is no entry for id=$id")))
     }
 }

--- a/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
@@ -27,7 +27,9 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
           typedStore.get(typedStoreId) match {
             case Right(Identified(_, t)) =>
               Right(Identified(Version(id, version), t))
-            case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
+            case Left(_: DoesNotExistError) =>
+              val error = new Throwable(s"Could not find maxima for id=$id")
+              Left(NoMaximaValueError(error))
             case Left(err: ReadError)       => Left(MaximaReadError(err.e))
           }
       }

--- a/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
@@ -30,7 +30,7 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
             case Left(_: DoesNotExistError) =>
               val error = new Throwable(s"Could not find maxima for id=$id")
               Left(NoMaximaValueError(error))
-            case Left(err: ReadError)       => Left(MaximaReadError(err.e))
+            case Left(err: ReadError) => Left(MaximaReadError(err.e))
           }
       }
 }

--- a/storage/src/main/scala/weco/storage/store/VersionedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/VersionedStore.scala
@@ -88,8 +88,9 @@ class VersionedStore[Id, V, T](
 
   def getLatest(id: Id): ReadEither =
     store.max(id).left.map {
-      case NoMaximaValueError(_) => NoVersionExistsError(s"There are no entries with id=$id")
-      case err                   => err
+      case NoMaximaValueError(_) =>
+        NoVersionExistsError(s"There are no entries with id=$id")
+      case err => err
     }
 
   def put(id: Version[Id, V])(t: T): WriteEither =
@@ -104,9 +105,10 @@ class VersionedStore[Id, V, T](
           s"Tried to store ${id.id} at version ${id.version}, but version ${latest.id.version} already exists"
         ))
       case Right(latest) if latest.id.version == id.version =>
-        Left(VersionAlreadyExistsError(
-          s"Tried to store ${id.id} at version ${id.version}, but that version already exists"
-        ))
+        Left(
+          VersionAlreadyExistsError(
+            s"Tried to store ${id.id} at version ${id.version}, but that version already exists"
+          ))
       case _ =>
         store.put(id)(t)
     }

--- a/storage/src/main/scala/weco/storage/store/VersionedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/VersionedStore.scala
@@ -82,13 +82,13 @@ class VersionedStore[Id, V, T](
     store.get(id) match {
       case r @ Right(_) => r
       case Left(DoesNotExistError(_)) =>
-        Left(NoVersionExistsError())
+        Left(NoVersionExistsError(s"There is no store entry for id=$id"))
       case Left(err) => Left(err)
     }
 
   def getLatest(id: Id): ReadEither =
     store.max(id).left.map {
-      case NoMaximaValueError(_) => NoVersionExistsError()
+      case NoMaximaValueError(_) => NoVersionExistsError(s"There are no entries with id=$id")
       case err                   => err
     }
 
@@ -100,9 +100,13 @@ class VersionedStore[Id, V, T](
         Right(Identified(id, t))
 
       case Right(latest) if O.gt(latest.id.version, id.version) =>
-        Left(HigherVersionExistsError())
+        Left(HigherVersionExistsError(
+          s"Tried to store ${id.id} at version ${id.version}, but version ${latest.id.version} already exists"
+        ))
       case Right(latest) if latest.id.version == id.version =>
-        Left(VersionAlreadyExistsError())
+        Left(VersionAlreadyExistsError(
+          s"Tried to store ${id.id} at version ${id.version}, but that version already exists"
+        ))
       case _ =>
         store.put(id)(t)
     }

--- a/storage/src/main/scala/weco/storage/store/dynamo/DynamoReadable.scala
+++ b/storage/src/main/scala/weco/storage/store/dynamo/DynamoReadable.scala
@@ -50,7 +50,9 @@ sealed trait DynamoReadable[Ident, DynamoIdent, EntryType, T]
         val daoReadError = new Error(s"DynamoReadError: ${err.toString}")
         Left(StoreReadError(daoReadError))
 
-      case Success(None) => Left(DoesNotExistError())
+      case Success(None) =>
+        val error = new Throwable(s"There is no Dynamo item with id=$id")
+        Left(DoesNotExistError(error))
 
       case Failure(err) => Left(StoreReadError(err))
     }
@@ -75,7 +77,7 @@ trait DynamoHashReadable[HashKey, V, T]
       if (entry.version == id.version) {
         Right(Identified(id, entry.payload))
       } else {
-        Left(NoVersionExistsError())
+        Left(NoVersionExistsError(s"There is no Dynamo item with id=$id"))
       }
     }
   }

--- a/storage/src/main/scala/weco/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/weco/storage/store/dynamo/DynamoStore.scala
@@ -38,7 +38,9 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
     getEntry(hashKey) match {
       case Right(value) =>
         Right(Identified(Version(value.hashKey, value.version), value.payload))
-      case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
+      case Left(_: DoesNotExistError) =>
+        val error = new Error(s"There are no Dynamo items with hash key id=$hashKey")
+        Left(NoMaximaValueError(error))
       case Left(err: ReadError)       => Left(MaximaReadError(err.e))
     }
 

--- a/storage/src/main/scala/weco/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/weco/storage/store/dynamo/DynamoStore.scala
@@ -39,9 +39,10 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
       case Right(value) =>
         Right(Identified(Version(value.hashKey, value.version), value.payload))
       case Left(_: DoesNotExistError) =>
-        val error = new Error(s"There are no Dynamo items with hash key id=$hashKey")
+        val error = new Error(
+          s"There are no Dynamo items with hash key id=$hashKey")
         Left(NoMaximaValueError(error))
-      case Left(err: ReadError)       => Left(MaximaReadError(err.e))
+      case Left(err: ReadError) => Left(MaximaReadError(err.e))
     }
 
   override protected val table =

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryStore.scala
@@ -29,9 +29,11 @@ class MemoryStore[Ident, T](initialEntries: Map[Ident, T])
 
     val result = entries.get(id) match {
       case Some(t) => Right(Identified(id, t))
-      case None    => Left(DoesNotExistError(
-        new Throwable(s"There is no entry for id=$id")
-      ))
+      case None =>
+        Left(
+          DoesNotExistError(
+            new Throwable(s"There is no entry for id=$id")
+          ))
     }
 
     debug(s"Got $result")

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryStore.scala
@@ -29,7 +29,9 @@ class MemoryStore[Ident, T](initialEntries: Map[Ident, T])
 
     val result = entries.get(id) match {
       case Some(t) => Right(Identified(id, t))
-      case None    => Left(DoesNotExistError())
+      case None    => Left(DoesNotExistError(
+        new Throwable(s"There is no entry for id=$id")
+      ))
     }
 
     debug(s"Got $result")

--- a/storage/src/main/scala/weco/storage/tags/memory/MemoryTags.scala
+++ b/storage/src/main/scala/weco/storage/tags/memory/MemoryTags.scala
@@ -11,7 +11,9 @@ class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]])
     synchronized {
       underlying.get(id) match {
         case Some(tags) => Right(Identified(id, tags))
-        case None       => Left(DoesNotExistError())
+        case None       => Left(DoesNotExistError(
+          new Throwable(s"There is no entry for id=$id")
+        ))
       }
     }
 

--- a/storage/src/main/scala/weco/storage/tags/memory/MemoryTags.scala
+++ b/storage/src/main/scala/weco/storage/tags/memory/MemoryTags.scala
@@ -11,9 +11,11 @@ class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]])
     synchronized {
       underlying.get(id) match {
         case Some(tags) => Right(Identified(id, tags))
-        case None       => Left(DoesNotExistError(
-          new Throwable(s"There is no entry for id=$id")
-        ))
+        case None =>
+          Left(
+            DoesNotExistError(
+              new Throwable(s"There is no entry for id=$id")
+            ))
       }
     }
 

--- a/storage/src/test/scala/weco/storage/store/memory/MemoryVersionedStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/memory/MemoryVersionedStoreTest.scala
@@ -89,7 +89,7 @@ class MemoryVersionedStoreTest
       String,
       Record])(testWith: TestWith[StoreImpl, R]): R =
     withVersionedStoreImpl(initialEntries, storeContext)(testWith)
-  
+
   it("allows writing the same value twice to a given id/version, even if a higher version exists") {
     val id = createIdent
     val t = createT

--- a/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
@@ -115,7 +115,7 @@ class MemoryPrefixTransferTest
   ): R = {
     val prefixTransfer = new MemoryMemoryLocationPrefixTransfer(initialEntries = srcStore.entries ++ dstStore.entries) {
       override def list(prefix: MemoryLocationPrefix): ListingResult =
-        Left(ListingFailure(prefix, error = new Throwable("BOOM!")))
+        Left(ListingFailure(prefix, e = new Throwable("BOOM!")))
     }
 
     testWith(prefixTransfer)

--- a/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
@@ -115,7 +115,7 @@ class MemoryPrefixTransferTest
   ): R = {
     val prefixTransfer = new MemoryMemoryLocationPrefixTransfer(initialEntries = srcStore.entries ++ dstStore.entries) {
       override def list(prefix: MemoryLocationPrefix): ListingResult =
-        Left(ListingFailure(prefix))
+        Left(ListingFailure(prefix, error = new Throwable("BOOM!")))
     }
 
     testWith(prefixTransfer)

--- a/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
@@ -76,7 +76,7 @@ class S3PrefixTransferTest
     implicit val listing: S3ObjectLocationListing =
       new S3ObjectLocationListing() {
         override def list(prefix: S3ObjectLocationPrefix): ListingResult =
-          Left(ListingFailure(prefix, error = new Throwable("BOOM!")))
+          Left(ListingFailure(prefix, e = new Throwable("BOOM!")))
       }
 
     implicit val transfer: S3Transfer = S3Transfer.apply

--- a/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
@@ -76,7 +76,7 @@ class S3PrefixTransferTest
     implicit val listing: S3ObjectLocationListing =
       new S3ObjectLocationListing() {
         override def list(prefix: S3ObjectLocationPrefix): ListingResult =
-          Left(ListingFailure(prefix))
+          Left(ListingFailure(prefix, error = new Throwable("BOOM!")))
       }
 
     implicit val transfer: S3Transfer = S3Transfer.apply


### PR DESCRIPTION
Previously we had a lot of errors defined like:

```scala
StorageError(e: Throwable = new Error())
```

This means the top-level exception message in the application logs is `java.lang.Error: null`, which is totally unhelpful.  These new messages add more context and should be easier to debug.

Spotted while trying to debug https://github.com/wellcomecollection/platform/issues/5287