### PR TITLE
Improve the error messages for failed assertions in ElasticsearchFixtures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Get slightly better error messages from the assertions in ElasticsearchFixtures.


### PR DESCRIPTION
This is to help me debug some weird CI failures in https://github.com/wellcomecollection/catalogue-pipeline/pull/1884