### PR TITLE
Add a shared trait for reading files from "resources" in tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Add a new helper trait for read files from the "resources" folder in the fixtures library.

--- a/fixtures/src/test/resources/greetings.txt
+++ b/fixtures/src/test/resources/greetings.txt
@@ -1,0 +1,3 @@
+hello world
+bonjour monde
+Hallo Welt

--- a/fixtures/src/test/scala/weco/fixtures/LocalResources.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalResources.scala
@@ -1,0 +1,18 @@
+package weco.fixtures
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
+
+trait LocalResources {
+  /** Returns the contents of a file in the "resources" folder. */
+  def readResource(name: String): String =
+    Source.fromResource(name).getLines.mkString("\n")
+}
+
+class LocalResourcesTest extends AnyFunSpec with Matchers with LocalResources {
+  it("reads a file") {
+    readResource("greetings.txt") shouldBe "hello world\nbonjour monde\nHallo Welt"
+  }
+}


### PR DESCRIPTION
We do this in a bunch of places, all with slightly different implementations, and I figured it was worth standardising.