### PR TITLE
Remove the unused DockerCompose settings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Remove some unused build settings from the scala-libs repo.
+There should be no user-visible effect.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -53,7 +53,6 @@ object Common {
     project
       .in(new File(folder))
       .settings(settings: _*)
-      .settings(DockerCompose.settings: _*)
       .enablePlugins(DockerComposePlugin)
       .dependsOn(dependsOn: _*)
       .settings(libraryDependencies ++= externalDependencies)

--- a/project/DockerCompose.scala
+++ b/project/DockerCompose.scala
@@ -1,8 +1,0 @@
-import sbt._
-import com.tapad.docker.DockerComposePlugin.autoImport._
-
-object DockerCompose {
-  val settings: Seq[Def.Setting[_]] = Seq(
-    composeNoBuild := true
-  )
-}


### PR DESCRIPTION
We get a warning that they're unused whenever we run sbt, so we might as well remove them (as we've done in other repos).