### PR TITLE
Add a dedicated exception `LargeStreamReaderCannotReadRange`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds a dedicated exception `LargeStreamReaderCannotReadRange` to the LargeStreamReader.
+
+If the large stream reader is unable to read a particular chunk, it exposes all the relevant information so an upstream caller can react appropriately (e.g. providing a more user-friendly error message).

--- a/storage/src/main/scala/weco/storage/services/LargeStreamReader.scala
+++ b/storage/src/main/scala/weco/storage/services/LargeStreamReader.scala
@@ -9,6 +9,12 @@ import weco.storage.{Identified, ReadError}
 
 import scala.collection.JavaConverters._
 
+class LargeStreamReaderCannotReadRange[Ident](
+  ident: Ident,
+  range: ByteRange,
+  err: ReadError
+) extends Throwable(s"Unable to read range $range from $ident: ${err.e}")
+
 /** If you hold open an InputStream for a long time, eventually the network times out
   * and you get an error.
   *
@@ -82,10 +88,7 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
     inner.retry(maxAttempts = retries)((ident, range)) match {
       case Right(bytes) => bytes
       case Left(err) =>
-        throw new RuntimeException(
-          s"Unable to read range $range from $ident: $err",
-          err.e
-        )
+        throw new LargeStreamReaderCannotReadRange(ident = ident, range = range, err = err)
     }
   }
 }

--- a/storage/src/main/scala/weco/storage/services/LargeStreamReader.scala
+++ b/storage/src/main/scala/weco/storage/services/LargeStreamReader.scala
@@ -88,7 +88,10 @@ trait LargeStreamReader[Ident] extends Readable[Ident, InputStreamWithLength] {
     inner.retry(maxAttempts = retries)((ident, range)) match {
       case Right(bytes) => bytes
       case Left(err) =>
-        throw new LargeStreamReaderCannotReadRange(ident = ident, range = range, err = err)
+        throw new LargeStreamReaderCannotReadRange(
+          ident = ident,
+          range = range,
+          err = err)
     }
   }
 }

--- a/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
+++ b/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
@@ -6,12 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.{RandomGenerators, TestWith}
 import weco.storage.models.ByteRange
 import weco.storage.streaming.Codec
-import weco.storage.{
-  DoesNotExistError,
-  ReadError,
-  RetryableError,
-  StoreReadError
-}
+import weco.storage.{DoesNotExistError, ReadError, RetryableError, StoreReadError}
 
 trait LargeStreamReaderTestCases[Ident, Namespace]
     extends AnyFunSpec
@@ -110,7 +105,7 @@ trait LargeStreamReaderTestCases[Ident, Namespace]
         }
       }
 
-      intercept[RuntimeException] {
+      intercept[LargeStreamReaderCannotReadRange[Ident]] {
         withLargeStreamReader(bufferSize = 500, rangedReader = brokenReader) {
           _.get(ident)
         }


### PR DESCRIPTION
Context for LargeStreamReader: https://alexwlchan.net/2019/09/streaming-large-s3-objects/

It reads a large stream as individual chunks and stitches them together into a single InputStream, but what if the first chunk succeeds but the second fails? Now we expose that error a bit better – because I want to catch it and provide a proper error in the storage service.

<img width="787" alt="Screenshot 2021-11-04 at 07 53 56" src="https://user-images.githubusercontent.com/301220/140276914-b827f8b3-1d90-4374-8ff6-1837eb223f5f.png">
