### PR TITLE
Add implicit decoders/encoders for NotificationMessage

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Add implicit JSON decoders/encoders for `NotificationMessage`.
+This should make compilation a little faster but otherwise have no user-visible effect.

--- a/messaging/src/main/scala/weco/messaging/memory/MemoryMessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/memory/MemoryMessageSender.scala
@@ -1,7 +1,7 @@
 package weco.messaging.memory
 
 import io.circe.Decoder
-import weco.json.JsonUtil._
+import weco.json.JsonUtil.fromJson
 import weco.messaging.{IndividualMessageSender, MessageSender}
 
 import scala.util.{Random, Try}

--- a/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
@@ -1,7 +1,17 @@
 package weco.messaging.sns
 
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.JsonKey
+import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 
 case class NotificationMessage(
   @JsonKey("Message") body: String
 )
+
+case object NotificationMessage {
+
+  // We use these implicits throughout the platform; cache them here to avoid
+  // re-deriving them repeatedly.
+  implicit val decoder: Decoder[NotificationMessage] = deriveConfiguredDecoder
+  implicit val encoder: Encoder[NotificationMessage] = deriveConfiguredEncoder
+}

--- a/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
@@ -3,6 +3,7 @@ package weco.messaging.sns
 import io.circe.generic.extras.JsonKey
 import io.circe.generic.extras.semiauto._
 import io.circe._
+import weco.json.JsonUtil._
 
 case class NotificationMessage(
   @JsonKey("Message") body: String

--- a/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/NotificationMessage.scala
@@ -1,8 +1,8 @@
 package weco.messaging.sns
 
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.extras.JsonKey
-import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
+import io.circe.generic.extras.semiauto._
+import io.circe._
 
 case class NotificationMessage(
   @JsonKey("Message") body: String

--- a/messaging/src/main/scala/weco/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/weco/messaging/sqs/SQSStream.scala
@@ -10,7 +10,7 @@ import grizzled.slf4j.Logging
 import io.circe.Decoder
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.Message
-import weco.json.JsonUtil._
+import weco.json.JsonUtil.fromJson
 import weco.json.exceptions.JsonDecodingError
 import weco.monitoring.Metrics
 

--- a/messaging/src/main/scala/weco/messaging/worker/SnsSqsTransform.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/SnsSqsTransform.scala
@@ -2,7 +2,7 @@ package weco.messaging.worker
 
 import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
 import io.circe.Decoder
-import weco.json.JsonUtil._
+import weco.json.JsonUtil.fromJson
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.worker.steps.MessageTransform
 

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -13,7 +13,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.model._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import weco.fixtures._
-import weco.json.JsonUtil._
+import weco.json.JsonUtil.toJson
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.sqs._
 import weco.monitoring.Metrics


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5359

Although it's a very small class, we use it *everywhere*. Let's shove an implicit encoder/decoder on the companion object (so we don't need to import anything extra), and save the compiler some work.