### PR TITLE
Use custom Scalatest matchers in JsonAssertions and TimeAssertions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,7 @@ steps:
           mount-ssh-agent: true
           volumes: [
             "$HOME/.aws:/root/.aws",
-            "$HOME/.docker:/root/.docker",
+            "$DOCKER_CONFIG:/root/.docker",
             "/var/run/docker.sock:/var/run/docker.sock",
           ]
           network: "host"
@@ -76,7 +76,7 @@ steps:
           mount-ssh-agent: true
           volumes: [
             "$HOME/.aws:/root/.aws",
-            "$HOME/.docker:/root/.docker",
+            "$DOCKER_CONFIG:/root/.docker",
             "/var/run/docker.sock:/var/run/docker.sock",
           ]
           network: "host"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This replaces the assert() helpers with custom Scalatest matchers in JsonAssertions and TimeAssertions, allowing you to write more Scalatest-like code.
+
+e.g.
+
+```diff
+-assertJsonStringsAreEqual(json1, json2)
++json1 shouldBe equivalentJsonTo(json2)
+```
+
+```diff
+-assertRecent(t)
++t shouldBe recent()
+```

--- a/elasticsearch/src/test/scala/weco/elasticsearch/ElasticsearchIndexCreatorTest.scala
+++ b/elasticsearch/src/test/scala/weco/elasticsearch/ElasticsearchIndexCreatorTest.scala
@@ -88,10 +88,7 @@ class ElasticsearchIndexCreatorTest
           val hits = response.result.hits.hits
           hits should have size 1
 
-          assertJsonStringsAreEqual(
-            hits.head.sourceAsString,
-            testObjectJson
-          )
+          hits.head.sourceAsString shouldBe equivalentJsonTo(testObjectJson)
         }
       }
     }
@@ -186,10 +183,7 @@ class ElasticsearchIndexCreatorTest
 
               hits should have size 1
 
-              assertJsonStringsAreEqual(
-                hits.head.sourceAsString,
-                compatibleTestObjectJson
-              )
+              hits.head.sourceAsString shouldBe equivalentJsonTo(compatibleTestObjectJson)
             }
           }
       }

--- a/elasticsearch/src/test/scala/weco/elasticsearch/ElasticsearchIndexCreatorTest.scala
+++ b/elasticsearch/src/test/scala/weco/elasticsearch/ElasticsearchIndexCreatorTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 import weco.json.JsonUtil._
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -42,7 +42,7 @@ class ElasticsearchIndexCreatorTest
     with ScalaFutures
     with Eventually
     with Matchers
-    with JsonAssertions
+    with JsonMatchers
     with BeforeAndAfterEach {
 
   val indexFields = Seq(

--- a/fixtures/src/test/scala/weco/fixtures/TimeMatchers.scala
+++ b/fixtures/src/test/scala/weco/fixtures/TimeMatchers.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.{BeMatcher, MatchResult}
 import java.time.Instant
 import scala.concurrent.duration._
 
-trait TimeAssertions extends Matchers {
+trait TimeMatchers {
   class InstantMatcher(within: Duration) extends BeMatcher[Instant] {
     override def apply(t: Instant): MatchResult = {
       val interval = Instant.now().toEpochMilli - t.toEpochMilli
@@ -23,7 +23,7 @@ trait TimeAssertions extends Matchers {
     new InstantMatcher(within)
 }
 
-class TimeAssertionsTest extends AnyFunSpec with Matchers with TimeAssertions {
+class TimeMatchersTest extends AnyFunSpec with Matchers with TimeMatchers {
   it("finds times that are recent") {
     Instant.now() shouldBe recent()
   }

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -40,7 +40,7 @@ class WellcomeHttpAppFeatureTest
                |}""".stripMargin
 
           withStringEntity(response.entity) {
-            assertJsonStringsAreEqual(_, expectedJson)
+            _ shouldBe equivalentJsonTo(expectedJson)
           }
         }
       }

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
 import weco.fixtures.TestWith
 import weco.json.JsonUtil.toJson
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 import weco.http.WellcomeHttpApp
 import weco.http.models.HTTPServerConfig
 import weco.http.monitoring.{HttpMetricResults, HttpMetrics}
@@ -21,7 +21,7 @@ import weco.monitoring.memory.MemoryMetrics
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait HttpFixtures extends Akka with ScalaFutures with Matchers
-  with JsonAssertions {
+  with JsonMatchers {
 
   private def whenRequestReady[R](
     r: HttpRequest

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -149,7 +149,7 @@ trait HttpFixtures extends Akka with ScalaFutures with Matchers
          |""".stripMargin
 
     withStringEntity(response.entity) {
-      assertJsonStringsAreEqual(_, expectedJson)
+      _ shouldBe equivalentJsonTo(expectedJson)
     }
   }
 

--- a/http/src/test/scala/weco/http/models/DisplayErrorTest.scala
+++ b/http/src/test/scala/weco/http/models/DisplayErrorTest.scala
@@ -3,10 +3,10 @@ package weco.http.models
 import akka.http.scaladsl.model.StatusCodes
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 import weco.http.json.DisplayJsonUtil._
 
-class DisplayErrorTest extends AnyFunSpec with Matchers with JsonAssertions {
+class DisplayErrorTest extends AnyFunSpec with Matchers with JsonMatchers {
   import DisplayError._
 
   it("serialises to JSON without a description") {

--- a/http/src/test/scala/weco/http/models/DisplayErrorTest.scala
+++ b/http/src/test/scala/weco/http/models/DisplayErrorTest.scala
@@ -12,8 +12,7 @@ class DisplayErrorTest extends AnyFunSpec with Matchers with JsonAssertions {
   it("serialises to JSON without a description") {
     val error = DisplayError(statusCode = StatusCodes.InternalServerError)
 
-    assertJsonStringsAreEqual(
-      toJson(error),
+    toJson(error) shouldBe equivalentJsonTo(
       s"""
          |{
          |  "errorType": "http",
@@ -28,8 +27,7 @@ class DisplayErrorTest extends AnyFunSpec with Matchers with JsonAssertions {
   it("serialises to JSON with a description") {
     val error = DisplayError(statusCode = StatusCodes.NotFound, description = "I couldn't find that!")
 
-    assertJsonStringsAreEqual(
-      toJson(error),
+    toJson(error) shouldBe equivalentJsonTo(
       s"""
          |{
          |  "errorType": "http",

--- a/json/src/test/scala/weco/json/JsonUtilTest.scala
+++ b/json/src/test/scala/weco/json/JsonUtilTest.scala
@@ -8,9 +8,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.JsonUtil._
 import weco.json.exceptions.JsonDecodingError
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 
-class JsonUtilTest extends AnyFunSpec with Matchers with JsonAssertions {
+class JsonUtilTest extends AnyFunSpec with Matchers with JsonMatchers {
   case class A(id: String, b: B)
   case class B(id: String, c: C)
   case class C(ints: List[Int])

--- a/json/src/test/scala/weco/json/JsonUtilTest.scala
+++ b/json/src/test/scala/weco/json/JsonUtilTest.scala
@@ -72,7 +72,7 @@ class JsonUtilTest extends AnyFunSpec with Matchers with JsonAssertions {
           |}
         """.stripMargin
 
-      assertJsonStringsAreEqual(triedString.get, expectedString)
+      triedString.get shouldBe equivalentJsonTo(expectedString)
     }
   }
 
@@ -85,8 +85,7 @@ class JsonUtilTest extends AnyFunSpec with Matchers with JsonAssertions {
         uri = new URI("https://wellcomecollection.org/")
       )
 
-      assertJsonStringsAreEqual(
-        toJson(website).get,
+      toJson(website).get shouldBe equivalentJsonTo(
         """
           |{
           |  "title": "Wellcome Collection",
@@ -120,13 +119,12 @@ class JsonUtilTest extends AnyFunSpec with Matchers with JsonAssertions {
         id = uuid
       )
 
-      assertJsonStringsAreEqual(
-        toJson(shipment).get,
+      toJson(shipment).get shouldBe equivalentJsonTo(
         s"""
-          |{
-          |  "name": "Red cars and yellow cars",
-          |  "id": "${uuid.toString}"
-          |}
+           |{
+           |  "name": "Red cars and yellow cars",
+           |  "id": "${uuid.toString}"
+           |}
         """.stripMargin
       )
     }
@@ -156,8 +154,7 @@ class JsonUtilTest extends AnyFunSpec with Matchers with JsonAssertions {
       val now = Instant.parse("2019-06-21T15:51:41.256Z")
       val event = Event(name = "this test", time = now)
 
-      assertJsonStringsAreEqual(
-        toJson(event).get,
+      toJson(event).get shouldBe equivalentJsonTo(
         s"""
            |{
            |  "name": "this test",

--- a/json/src/test/scala/weco/json/TypedStringTest.scala
+++ b/json/src/test/scala/weco/json/TypedStringTest.scala
@@ -3,9 +3,9 @@ package weco.json
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.JsonUtil._
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 
-class TypedStringTest extends AnyFunSpec with Matchers with JsonAssertions {
+class TypedStringTest extends AnyFunSpec with Matchers with JsonMatchers {
   class Shape(val underlying: String) extends TypedString[Shape]
 
   object Shape extends TypedStringOps[Shape] {

--- a/json/src/test/scala/weco/json/TypedStringTest.scala
+++ b/json/src/test/scala/weco/json/TypedStringTest.scala
@@ -68,10 +68,11 @@ class TypedStringTest extends AnyFunSpec with Matchers with JsonAssertions {
     it("serialises to a string") {
       val triangle = Shape("triangle")
 
-      assertJsonStringsAreEqual(toJson(triangle).get,
+      toJson(triangle).get shouldBe equivalentJsonTo(
         """
           |"triangle"
-          |""".stripMargin)
+          |""".stripMargin
+      )
     }
 
     it("deserialises from a string") {

--- a/json/src/test/scala/weco/json/utils/JsonAssertions.scala
+++ b/json/src/test/scala/weco/json/utils/JsonAssertions.scala
@@ -1,30 +1,77 @@
 package weco.json.utils
 
-import io.circe.Json
-import org.scalatest.Assertion
+import io.circe.{Json, ParsingFailure}
 import io.circe.parser._
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{BeMatcher, MatchResult}
 
 trait JsonAssertions extends Matchers {
+  class JsonMatcher(jsonString1: String) extends BeMatcher[String] {
+    override def apply(jsonString2: String): MatchResult = {
+      val json1 = parseOrElse(jsonString1)
+      val json2 = parseOrElse(jsonString2)
 
-  def assertJsonStringsAreEqual(json1: String, json2: String): Assertion = {
-    val tree1 = parseOrElse(json1)
-    val tree2 = parseOrElse(json2)
-    tree1 shouldBe tree2
-  }
-
-  def assertJsonStringsAreDifferent(json1: String, json2: String): Assertion = {
-    val tree1 = parseOrElse(json1)
-    val tree2 = parseOrElse(json2)
-    tree1 shouldNot be(tree2)
-  }
-
-  private def parseOrElse(jsonString: String): Json =
-    parse(jsonString) match {
-      case Right(t) => t
-      case Left(err) => {
-        println(s"Error trying to parse string <<$jsonString>>")
-        throw err
-      }
+      MatchResult(
+        json1 == json2,
+        s"JSON strings were not equivalent:\n$json1\n$json2",
+        s"JSON strings were equivalent"
+      )
     }
+
+    private def parseOrElse(jsonString: String): Json =
+      parse(jsonString) match {
+        case Right(t) => t
+        case Left(err) =>
+          println(s"Error trying to parse string <<$jsonString>>")
+          throw err
+      }
+  }
+
+  def equivalentJsonTo(jsonString: String): JsonMatcher =
+    new JsonMatcher(jsonString)
+}
+
+class JsonAssertionsTest extends AnyFunSpec with Matchers with JsonAssertions {
+  val pentagon1 =
+    s"""
+       |{
+       |  "name": "pentagon",
+       |  "sides": 5
+       |}
+       |""".stripMargin
+
+  val pentagon2 =
+    s"""
+       |{
+       |  "sides": 5,
+       |  "name": "pentagon"
+       |}
+       |""".stripMargin
+
+  val hexagon =
+    s"""
+       |{
+       |  "sides": 6,
+       |  "name": "hexagon"
+       |}
+       |""".stripMargin
+
+  it("finds JSON strings which are equivalent") {
+    pentagon1 shouldBe equivalentJsonTo(pentagon2)
+  }
+
+  it("finds JSON strings which are different") {
+    pentagon1 should not be equivalentJsonTo(hexagon)
+  }
+
+  it("throws if one of the strings is not JSON") {
+    intercept[ParsingFailure] {
+      "notJson" shouldBe equivalentJsonTo(hexagon)
+    }
+
+    intercept[ParsingFailure] {
+      hexagon shouldBe equivalentJsonTo("notJson")
+    }
+  }
 }

--- a/json/src/test/scala/weco/json/utils/JsonMatchers.scala
+++ b/json/src/test/scala/weco/json/utils/JsonMatchers.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 
-trait JsonAssertions extends Matchers {
+trait JsonMatchers {
   class JsonMatcher(jsonString1: String) extends BeMatcher[String] {
     override def apply(jsonString2: String): MatchResult = {
       val json1 = parseOrElse(jsonString1)
@@ -32,7 +32,7 @@ trait JsonAssertions extends Matchers {
     new JsonMatcher(jsonString)
 }
 
-class JsonAssertionsTest extends AnyFunSpec with Matchers with JsonAssertions {
+class JsonMatchersTest extends AnyFunSpec with Matchers with JsonMatchers {
   val pentagon1 =
     s"""
        |{

--- a/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
@@ -79,7 +79,7 @@ class MessageSenderTest extends AnyFunSpec with Matchers with JsonAssertions wit
 
     Seq(dog, octopus, snake).zip(sender.messages).map {
       case (animal, message) =>
-        assertJsonStringsAreEqual(toJson(animal).get, message.body)
+        toJson(animal).get shouldBe equivalentJsonTo(message.body)
     }
   }
 

--- a/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.fixtures.RandomGenerators
 import weco.json.JsonUtil._
-import weco.json.utils.JsonAssertions
+import weco.json.utils.JsonMatchers
 import weco.messaging.memory.{
   MemoryIndividualMessageSender,
   MemoryMessageSender
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Success, Try}
 
-class MessageSenderTest extends AnyFunSpec with Matchers with JsonAssertions with ScalaFutures with RandomGenerators {
+class MessageSenderTest extends AnyFunSpec with Matchers with JsonMatchers with ScalaFutures with RandomGenerators {
   it("sends individual messages") {
     val sender = new MemoryIndividualMessageSender()
 

--- a/sierra/src/test/scala/weco/sierra/http/SierraOauthHttpClientTest.scala
+++ b/sierra/src/test/scala/weco/sierra/http/SierraOauthHttpClientTest.scala
@@ -90,7 +90,7 @@ class SierraOauthHttpClientTest extends AnyFunSpec with Matchers with Akka with 
 
       whenReady(future) { resp =>
         withStringEntity(resp.entity) {
-          assertJsonStringsAreEqual(_, itemJson)
+          _ shouldBe equivalentJsonTo(itemJson)
         }
       }
     }
@@ -180,7 +180,7 @@ class SierraOauthHttpClientTest extends AnyFunSpec with Matchers with Akka with 
 
       whenReady(future1) { resp1 =>
         withStringEntity(resp1.entity) {
-          assertJsonStringsAreEqual(_, itemJson)
+          _ shouldBe equivalentJsonTo(itemJson)
         }
       }
 
@@ -190,7 +190,7 @@ class SierraOauthHttpClientTest extends AnyFunSpec with Matchers with Akka with 
 
       whenReady(future2) { resp2 =>
         withStringEntity(resp2.entity) {
-          assertJsonStringsAreEqual(_, itemJson)
+          _ shouldBe equivalentJsonTo(itemJson)
         }
       }
     }

--- a/sierra/src/test/scala/weco/sierra/models/marc/MarcFieldTest.scala
+++ b/sierra/src/test/scala/weco/sierra/models/marc/MarcFieldTest.scala
@@ -3,9 +3,8 @@ package weco.sierra.models.marc
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.JsonUtil._
-import weco.json.utils.JsonAssertions
 
-class MarcFieldTest extends AnyFunSpec with Matchers with JsonAssertions {
+class MarcFieldTest extends AnyFunSpec with Matchers {
 
   it("reads a JSON string as a long-form VarField") {
     val jsonString = s"""{


### PR DESCRIPTION
This is something I spotted while doing the merger work (it wasn't my idea; I don't know who added it originally) that I thought would be good to roll out to more places.