### PR TITLE
Use LocalStack for testing the messaging libraries

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+Change our SNS and SQS fixture to use a LocalStack container to mock cloud services, instead of the `fake-sns` and `elasticmq` containers we were using previously.
+The `fake-sns` image is no longer maintained, and prevents us from using newer SNS APIs in our libraries.
+
+Downstream users will need to replace `elasticmq` with `localstack` in their Docker Compose files.

--- a/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
@@ -1,3 +1,27 @@
-package weco.fixtures class LocalstackFixtures {
+package weco.fixtures
 
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.regions.Region
+
+import java.net.URI
+
+trait LocalStackFixtures {
+  val region: Region = Region.of("localhost")
+
+  val port = 4566
+  val endpoint = new URI(s"http://localhost:$port")
+
+  // The LocalStack container divides resources by credentials, i.e. if you connect
+  // with key1/secret1, you'll see a different set of resources to key2/secret2.
+  //
+  // This means it's important for us to use a consistent set of credentials across
+  // all uses of localstack, otherwise resources will be not found because they're
+  // attached to another "account".
+  //
+  val credentials: StaticCredentialsProvider =
+    StaticCredentialsProvider.create(
+      AwsBasicCredentials.create("access", "key"))
 }

--- a/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
@@ -1,0 +1,3 @@
+package weco.fixtures class LocalstackFixtures {
+
+}

--- a/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
@@ -14,7 +14,7 @@ trait LocalStackFixtures {
   val port = 4566
   val endpoint = new URI(s"http://localhost:$port")
 
-  // The LocalStack container divides resources by credentials, i.e. if you connect
+  // The LocalStack container divides resources by credentials, e.g. if you connect
   // with key1/secret1, you'll see a different set of resources to key2/secret2.
   //
   // This means it's important for us to use a consistent set of credentials across

--- a/messaging/docker-compose.yml
+++ b/messaging/docker-compose.yml
@@ -1,11 +1,8 @@
 version: "2.1"
 services:
-  sns:
-    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/fake-sns"
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+    environment:
+      - SERVICES=sns,sqs
     ports:
-      - "9292:9292"
-  sqs:
-    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
-    ports:
-      - "9324:9324"
-      - "4789:9324"
+      - "4566:4566"

--- a/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
@@ -1,10 +1,5 @@
 package weco.messaging.fixtures
 
-import software.amazon.awssdk.auth.credentials.{
-  AwsBasicCredentials,
-  StaticCredentialsProvider
-}
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.{
   CreateTopicRequest,
@@ -16,8 +11,6 @@ import weco.json.JsonUtil._
 import weco.messaging.fixtures.SQS.Queue
 import weco.messaging.sns.NotificationMessage
 
-import java.net.URI
-
 object SNS {
   case class Topic(arn: String, destinationQueue: Queue) {
     override def toString = s"SNS.Topic($arn)"
@@ -28,15 +21,12 @@ trait SNS extends SQS {
 
   import SNS._
 
-  private val localSNSEndpointUrl = "http://localhost:4566"
-
   implicit val snsClient: SnsClient =
     SnsClient
       .builder()
-      .region(Region.of("localhost"))
-      .credentialsProvider(StaticCredentialsProvider.create(
-        AwsBasicCredentials.create("access", "key")))
-      .endpointOverride(new URI(localSNSEndpointUrl))
+      .region(region)
+      .credentialsProvider(credentials)
+      .endpointOverride(endpoint)
       .build()
 
   def createTopicName: String =

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -5,13 +5,8 @@ import grizzled.slf4j.Logging
 import io.circe.Encoder
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.auth.credentials.{
-  AwsBasicCredentials,
-  StaticCredentialsProvider
-}
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.sqs.model._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model._
 import weco.fixtures._
 import weco.json.JsonUtil.toJson
 import weco.messaging.sns.NotificationMessage
@@ -19,7 +14,6 @@ import weco.messaging.sqs._
 import weco.monitoring.Metrics
 import weco.monitoring.memory.MemoryMetrics
 
-import java.net.URI
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -32,11 +26,11 @@ object SQS {
   case class QueuePair(queue: Queue, dlq: Queue)
 }
 
-trait SQS extends Matchers with Logging with RandomGenerators {
+trait SQS extends Matchers with Logging with RandomGenerators with LocalStackFixtures {
 
   import SQS._
 
-  private val sqsInternalEndpointUrl = "http://sqs:4566"
+  private val sqsInternalEndpointUrl = s"http://sqs:$port"
 
   def endpoint(queue: Queue) =
     s"aws-sqs://${queue.name}?amazonSQSEndpoint=$sqsInternalEndpointUrl&accessKey=&secretKey="
@@ -44,10 +38,9 @@ trait SQS extends Matchers with Logging with RandomGenerators {
   implicit val asyncSqsClient: SqsAsyncClient =
     SqsAsyncClient
       .builder()
-      .region(Region.of("localhost"))
-      .credentialsProvider(StaticCredentialsProvider.create(
-        AwsBasicCredentials.create("access", "key")))
-      .endpointOverride(new URI("http://localhost:4566"))
+      .region(region)
+      .credentialsProvider(credentials)
+      .endpointOverride(endpoint)
       .build()
 
   private def setQueueAttribute(

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -26,7 +26,11 @@ object SQS {
   case class QueuePair(queue: Queue, dlq: Queue)
 }
 
-trait SQS extends Matchers with Logging with RandomGenerators with LocalStackFixtures {
+trait SQS
+    extends Matchers
+    with Logging
+    with RandomGenerators
+    with LocalStackFixtures {
 
   import SQS._
 

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -36,7 +36,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
 
   import SQS._
 
-  private val sqsInternalEndpointUrl = "http://sqs:9324"
+  private val sqsInternalEndpointUrl = "http://sqs:4566"
 
   def endpoint(queue: Queue) =
     s"aws-sqs://${queue.name}?amazonSQSEndpoint=$sqsInternalEndpointUrl&accessKey=&secretKey="
@@ -47,7 +47,7 @@ trait SQS extends Matchers with Logging with RandomGenerators {
       .region(Region.of("localhost"))
       .credentialsProvider(StaticCredentialsProvider.create(
         AwsBasicCredentials.create("access", "key")))
-      .endpointOverride(new URI("http://localhost:9324"))
+      .endpointOverride(new URI("http://localhost:4566"))
       .build()
 
   private def setQueueAttribute(

--- a/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
@@ -8,7 +8,12 @@ import weco.messaging.fixtures.SNS
 
 import scala.util.{Failure, Success}
 
-class SNSMessageSenderTest extends AnyFunSpec with Matchers with SNS with Eventually with IntegrationPatience {
+class SNSMessageSenderTest
+    extends AnyFunSpec
+    with Matchers
+    with SNS
+    with Eventually
+    with IntegrationPatience {
   it("sends messages to SNS") {
     withLocalSnsTopic { topic =>
       val sender = new SNSIndividualMessageSender(snsClient)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -155,6 +155,11 @@ object Dependencies {
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % versions.jackson
   )
 
+  val localstackDependencies = Seq(
+    "software.amazon.awssdk" % "auth" % versions.aws2,
+    "software.amazon.awssdk" % "regions" % versions.aws2
+  )
+
   val monitoringDependencies = Seq(
     "software.amazon.awssdk" % "cloudwatch" % versions.aws2
   ) ++
@@ -179,7 +184,8 @@ object Dependencies {
 
   val fixturesDependencies: Seq[ModuleID] =
     sl4jDependencies ++
-      scalatestDependencies
+      scalatestDependencies ++
+      localstackDependencies
 
   val typesafeAppDependencies =
     akkaDependencies ++

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -166,8 +166,7 @@ object Dependencies {
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakka
     // This needs to be excluded because it conflicts with aws http client "netty-nio-client"
     // and it also causes weird leaks between tests
-      exclude ("com.github.matsluni", "aws-spi-akka-http_2.12"),
-    "io.circe" %% "circe-yaml" % versions.circe
+      exclude ("com.github.matsluni", "aws-spi-akka-http_2.12")
   ) ++
     openTracingDependencies ++
     elasticApmBridgeDependencies ++


### PR DESCRIPTION
Switching to LocalStack means a few things:

* We can bin our mirrored copy of `elasticmq` and `fake-sns`
* We can bin the `fake-sns` Docker image we're supposedly maintaining: https://github.com/wellcomecollection/dockerfiles/tree/main/fake-sns
* We can use more up-to-date SNS APIs, like https://github.com/wellcomecollection/platform/issues/5371