### PR TITLE
Add retrying logic for transient AWS network errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,11 @@
 RELEASE_TYPE: major
 
-This changes the signature of `MessageSender.send` from `Try[Unit]` to `Either[MessageSenderError, Unit]`.
+This release adds better retrying when there are network connectivity issues with SNS and S3, in particular:
 
-This means we can better distinguish errors when we send message notifications, e.g. we can mark a DNS issue when connecting to SNS as retryable.
+-   when we can resolve the endpoint, but can't connect
+-   when we can't resolve the endpoint
 
+Both of these errors will be instances of `RetryableError`, and should be retried appropriately.
+
+As a side effect, the signature of `MessageSender.send` has changed from `Try[Unit]` to `Either[MessageSender, Unit]`, so we can better distinguish errors when we send message notifications.
 Downstream users will need to adapt to the new function signature, and may want to add tests that they retry any errors that are marked as retryable.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: major
+
+This changes the signature of `MessageSender.send` from `Try[Unit]` to `Either[MessageSenderError, Unit]`.
+
+This means we can better distinguish errors when we send message notifications, e.g. we can mark a DNS issue when connecting to SNS as retryable.
+
+Downstream users will need to adapt to the new function signature, and may want to add tests that they retry any errors that are marked as retryable.

--- a/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalStackFixtures.scala
@@ -11,8 +11,8 @@ import java.net.URI
 trait LocalStackFixtures {
   val region: Region = Region.of("localhost")
 
-  val port = 4566
-  val endpoint = new URI(s"http://localhost:$port")
+  val localStackPort = 4566
+  val localStackEndpoint = new URI(s"http://localhost:$localStackPort")
 
   // The LocalStack container divides resources by credentials, e.g. if you connect
   // with key1/secret1, you'll see a different set of resources to key2/secret2.

--- a/messaging/src/main/scala/weco/messaging/MessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/MessageSender.scala
@@ -9,7 +9,8 @@ import scala.util.{Failure, Success}
 trait IndividualMessageSender[Destination] {
   type MessageSenderResult = Either[MessageSenderError, Unit]
 
-  def send(body: String)(subject: String, destination: Destination): MessageSenderResult
+  def send(body: String)(subject: String,
+                         destination: Destination): MessageSenderResult
 
   def sendT[T](t: T)(subject: String, destination: Destination)(
     implicit encoder: Encoder[T]): MessageSenderResult =

--- a/messaging/src/main/scala/weco/messaging/MessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/MessageSender.scala
@@ -4,41 +4,48 @@ import grizzled.slf4j.Logging
 import io.circe.Encoder
 import weco.json.JsonUtil.toJson
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 trait IndividualMessageSender[Destination] {
-  def send(body: String)(subject: String, destination: Destination): Try[Unit]
+  type MessageSenderResult = Either[MessageSenderError, Unit]
+
+  def send(body: String)(subject: String, destination: Destination): MessageSenderResult
 
   def sendT[T](t: T)(subject: String, destination: Destination)(
-    implicit encoder: Encoder[T]): Try[Unit] =
-    toJson(t).flatMap { send(_)(subject, destination) }
+    implicit encoder: Encoder[T]): MessageSenderResult =
+    toJson(t) match {
+      case Success(jsonString) => send(jsonString)(subject, destination)
+      case Failure(e)          => Left(MessageSenderError.JsonEncodingError(e))
+    }
 }
 
 trait MessageSender[Destination] extends Logging {
+  type MessageSenderResult = Either[MessageSenderError, Unit]
+
   protected val underlying: IndividualMessageSender[Destination]
 
   val subject: String
   val destination: Destination
 
-  def send(body: String): Try[Unit] =
+  def send(body: String): MessageSenderResult =
     underlying.send(body)(subject, destination) match {
-      case Failure(err) =>
+      case Left(err) =>
         error(
           s"Unable to send message (body=$body) to destination $destination: $err",
-          err)
-        Failure(err)
+          err.e)
+        Left(err)
 
-      case Success(_) => Success(())
+      case Right(_) => Right(())
     }
 
-  def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+  def sendT[T](t: T)(implicit encoder: Encoder[T]): MessageSenderResult =
     underlying.sendT[T](t)(subject, destination) match {
-      case Failure(err) =>
+      case Left(err) =>
         error(
           s"Unable to send message (t=$t) to destination $destination: $err",
-          err)
-        Failure(err)
+          err.e)
+        Left(err)
 
-      case Success(_) => Success(())
+      case Right(_) => Right(())
     }
 }

--- a/messaging/src/main/scala/weco/messaging/MessagingError.scala
+++ b/messaging/src/main/scala/weco/messaging/MessagingError.scala
@@ -1,0 +1,13 @@
+package weco.messaging
+
+sealed trait MessagingError {
+  val e: Throwable
+}
+
+sealed trait MessageSenderError extends MessagingError
+
+object MessageSenderError {
+  case class JsonEncodingError(e: Throwable) extends MessageSenderError
+  case class DestinationDoesNotExist(e: Throwable) extends MessageSenderError
+  case class UnknownError(e: Throwable) extends MessageSenderError
+}

--- a/messaging/src/main/scala/weco/messaging/memory/MemoryMessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/memory/MemoryMessageSender.scala
@@ -4,7 +4,7 @@ import io.circe.Decoder
 import weco.json.JsonUtil.fromJson
 import weco.messaging.{IndividualMessageSender, MessageSender}
 
-import scala.util.{Random, Try}
+import scala.util.Random
 
 class MemoryIndividualMessageSender extends IndividualMessageSender[String] {
   case class MemoryMessage(
@@ -16,11 +16,12 @@ class MemoryIndividualMessageSender extends IndividualMessageSender[String] {
   var messages: List[MemoryMessage] = List.empty
 
   override def send(body: String)(subject: String,
-                                  destination: String): Try[Unit] = Try {
+                                  destination: String): MessageSenderResult =
     this.synchronized {
       messages = messages :+ MemoryMessage(body, subject, destination)
+
+      Right(())
     }
-  }
 
   def getMessages[T]()(implicit decoder: Decoder[T]): Seq[T] =
     messages

--- a/messaging/src/main/scala/weco/messaging/sns/SNSMessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/SNSMessageSender.scala
@@ -4,21 +4,28 @@ import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import weco.messaging.{IndividualMessageSender, MessageSender}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class SNSIndividualMessageSender(
   snsClient: SnsClient,
 ) extends IndividualMessageSender[SNSConfig] {
   override def send(message: String)(subject: String,
-                                     destination: SNSConfig): Try[Unit] = Try {
-    snsClient.publish(
-      PublishRequest
-        .builder()
-        .message(message)
-        .subject(subject)
-        .topicArn(destination.topicArn)
-        .build()
-    )
+                                     destination: SNSConfig): MessageSenderResult = {
+    val result = Try {
+      snsClient.publish(
+        PublishRequest
+          .builder()
+          .message(message)
+          .subject(subject)
+          .topicArn(destination.topicArn)
+          .build()
+      )
+    }
+
+    result match {
+      case Success(_) => Right(())
+      case Failure(e) => Left(SnsErrors.sendErrors(e))
+    }
   }
 }
 

--- a/messaging/src/main/scala/weco/messaging/sns/SNSMessageSender.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/SNSMessageSender.scala
@@ -9,8 +9,9 @@ import scala.util.{Failure, Success, Try}
 class SNSIndividualMessageSender(
   snsClient: SnsClient,
 ) extends IndividualMessageSender[SNSConfig] {
-  override def send(message: String)(subject: String,
-                                     destination: SNSConfig): MessageSenderResult = {
+  override def send(message: String)(
+    subject: String,
+    destination: SNSConfig): MessageSenderResult = {
     val result = Try {
       snsClient.publish(
         PublishRequest

--- a/messaging/src/main/scala/weco/messaging/sns/SnsErrors.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/SnsErrors.scala
@@ -13,10 +13,13 @@ object SnsErrors {
     case exc: SnsException if exc.statusCode() == 500 =>
       new MessageSenderError.UnknownError(exc) with RetryableError
 
-    case exc: SdkClientException if exc.getMessage.startsWith("Unable to execute HTTP request") =>
+    case exc: SdkClientException
+        if exc.getMessage.startsWith("Unable to execute HTTP request") =>
       new MessageSenderError.UnknownError(exc) with RetryableError
 
-    case exc: SdkClientException if exc.getMessage.startsWith("Received an UnknownHostException when attempting to interact with a service") =>
+    case exc: SdkClientException
+        if exc.getMessage.startsWith(
+          "Received an UnknownHostException when attempting to interact with a service") =>
       new MessageSenderError.UnknownError(exc) with RetryableError
 
     case exc => MessageSenderError.UnknownError(exc)

--- a/messaging/src/main/scala/weco/messaging/sns/SnsErrors.scala
+++ b/messaging/src/main/scala/weco/messaging/sns/SnsErrors.scala
@@ -1,0 +1,24 @@
+package weco.messaging.sns
+
+import software.amazon.awssdk.core.exception.SdkClientException
+import software.amazon.awssdk.services.sns.model.SnsException
+import weco.errors.RetryableError
+import weco.messaging.MessageSenderError
+
+object SnsErrors {
+  val sendErrors: PartialFunction[Throwable, MessageSenderError] = {
+    case exc: SnsException if exc.statusCode() == 404 =>
+      MessageSenderError.DestinationDoesNotExist(exc)
+
+    case exc: SnsException if exc.statusCode() == 500 =>
+      new MessageSenderError.UnknownError(exc) with RetryableError
+
+    case exc: SdkClientException if exc.getMessage.startsWith("Unable to execute HTTP request") =>
+      new MessageSenderError.UnknownError(exc) with RetryableError
+
+    case exc: SdkClientException if exc.getMessage.startsWith("Received an UnknownHostException when attempting to interact with a service") =>
+      new MessageSenderError.UnknownError(exc) with RetryableError
+
+    case exc => MessageSenderError.UnknownError(exc)
+  }
+}

--- a/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
@@ -6,15 +6,10 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.RandomGenerators
 import weco.json.JsonUtil._
 import weco.json.utils.JsonAssertions
-import weco.messaging.memory.{
-  MemoryIndividualMessageSender,
-  MemoryMessageSender
-}
+import weco.messaging.memory.{MemoryIndividualMessageSender, MemoryMessageSender}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.concurrent.Future
-import scala.util.{Success, Try}
 
 class MessageSenderTest
     extends AnyFunSpec
@@ -27,14 +22,12 @@ class MessageSenderTest
 
     sender.send("hello world")(
       subject = "my first message",
-      destination = "greetings") shouldBe Success(())
-    sender.send("guten tag")(subject = "auf deutsch", destination = "greetings") shouldBe Success(
-      ())
-    sender.send("你好")(subject = "中文", destination = "greetings") shouldBe Success(
-      ())
+      destination = "greetings") shouldBe Right(())
+    sender.send("guten tag")(subject = "auf deutsch", destination = "greetings") shouldBe Right(())
+    sender.send("你好")(subject = "中文", destination = "greetings") shouldBe Right(())
     sender.send("chinese")(
       subject = "a non-alphabet language",
-      destination = "languages") shouldBe Success(())
+      destination = "languages") shouldBe Right(())
 
     sender.messages shouldBe List(
       sender.MemoryMessage("hello world", "my first message", "greetings"),
@@ -49,7 +42,7 @@ class MessageSenderTest
 
     def send(body: String,
              subject: String,
-             destination: String): Future[Try[Unit]] =
+             destination: String): Future[_] =
       Future(sender.send(body)(subject, destination))
 
     val toSend = Function.tupled(send _)
@@ -67,7 +60,7 @@ class MessageSenderTest
 
     whenReady(eventuallyResults) { results =>
       sender.messages.size shouldBe messages.size
-      results.foreach(_ shouldBe Success(()))
+      results.foreach(_ shouldBe Right(()))
       sender.messages.toSet shouldBe expectedResults
     }
   }
@@ -82,8 +75,7 @@ class MessageSenderTest
     val snake = Animal(name = "snake", legs = 0)
 
     Seq(dog, octopus, snake).map { animal =>
-      sender.sendT(animal)(subject = "animals", destination = "all creatures") shouldBe Success(
-        ())
+      sender.sendT(animal)(subject = "animals", destination = "all creatures") shouldBe Right(())
     }
 
     Seq(dog, octopus, snake).zip(sender.messages).map {
@@ -105,7 +97,7 @@ class MessageSenderTest
     containers.map { c =>
       sender.sendT[Container](c)(
         destination = "containers",
-        subject = "stuff to store things in") shouldBe Success(())
+        subject = "stuff to store things in") shouldBe Right(())
     }
 
     containers.zip(sender.messages).map {
@@ -120,10 +112,10 @@ class MessageSenderTest
       override val subject = "ideas for my design"
     }
 
-    sender.send("red") shouldBe Success(())
-    sender.send("yellow") shouldBe Success(())
-    sender.send("green") shouldBe Success(())
-    sender.send("blue") shouldBe Success(())
+    sender.send("red") shouldBe Right(())
+    sender.send("yellow") shouldBe Right(())
+    sender.send("green") shouldBe Right(())
+    sender.send("blue") shouldBe Right(())
 
     sender.messages.map { _.destination } shouldBe Seq(
       "colours",
@@ -145,9 +137,9 @@ class MessageSenderTest
 
     case class Tree(name: String)
 
-    sender.sendT(Tree("oak")) shouldBe Success(())
-    sender.sendT(Tree("ash")) shouldBe Success(())
-    sender.sendT(Tree("yew")) shouldBe Success(())
+    sender.sendT(Tree("oak")) shouldBe Right(())
+    sender.sendT(Tree("ash")) shouldBe Right(())
+    sender.sendT(Tree("yew")) shouldBe Right(())
 
     sender.messages.map { _.destination } shouldBe Seq(
       "trees",
@@ -164,7 +156,7 @@ class MessageSenderTest
     val sender = new MemoryMessageSender()
 
     containers.map { c =>
-      sender.sendT[Container](c) shouldBe Success(())
+      sender.sendT[Container](c) shouldBe Right(())
     }
 
     containers.zip(sender.messages).map {

--- a/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/MessageSenderTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.RandomGenerators
 import weco.json.JsonUtil._
 import weco.json.utils.JsonAssertions
-import weco.messaging.memory.{MemoryIndividualMessageSender, MemoryMessageSender}
+import weco.messaging.memory.{
+  MemoryIndividualMessageSender,
+  MemoryMessageSender
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -23,8 +26,10 @@ class MessageSenderTest
     sender.send("hello world")(
       subject = "my first message",
       destination = "greetings") shouldBe Right(())
-    sender.send("guten tag")(subject = "auf deutsch", destination = "greetings") shouldBe Right(())
-    sender.send("你好")(subject = "中文", destination = "greetings") shouldBe Right(())
+    sender.send("guten tag")(subject = "auf deutsch", destination = "greetings") shouldBe Right(
+      ())
+    sender.send("你好")(subject = "中文", destination = "greetings") shouldBe Right(
+      ())
     sender.send("chinese")(
       subject = "a non-alphabet language",
       destination = "languages") shouldBe Right(())
@@ -40,9 +45,7 @@ class MessageSenderTest
   it("can send many messages in parallel") {
     val sender = new MemoryIndividualMessageSender()
 
-    def send(body: String,
-             subject: String,
-             destination: String): Future[_] =
+    def send(body: String, subject: String, destination: String): Future[_] =
       Future(sender.send(body)(subject, destination))
 
     val toSend = Function.tupled(send _)
@@ -75,7 +78,8 @@ class MessageSenderTest
     val snake = Animal(name = "snake", legs = 0)
 
     Seq(dog, octopus, snake).map { animal =>
-      sender.sendT(animal)(subject = "animals", destination = "all creatures") shouldBe Right(())
+      sender.sendT(animal)(subject = "animals", destination = "all creatures") shouldBe Right(
+        ())
     }
 
     Seq(dog, octopus, snake).zip(sender.messages).map {

--- a/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
@@ -1,15 +1,13 @@
 package weco.messaging.fixtures
 
 import software.amazon.awssdk.services.sns.SnsClient
-import software.amazon.awssdk.services.sns.model.{
-  CreateTopicRequest,
-  DeleteTopicRequest,
-  SubscribeRequest
-}
+import software.amazon.awssdk.services.sns.model.{CreateTopicRequest, DeleteTopicRequest, SubscribeRequest}
 import weco.fixtures._
 import weco.json.JsonUtil._
 import weco.messaging.fixtures.SQS.Queue
 import weco.messaging.sns.NotificationMessage
+
+import java.net.URI
 
 object SNS {
   case class Topic(arn: String, destinationQueue: Queue) {
@@ -21,13 +19,16 @@ trait SNS extends SQS {
 
   import SNS._
 
-  implicit val snsClient: SnsClient =
+  def createClientWithEndpoint(uri: URI): SnsClient =
     SnsClient
       .builder()
       .region(region)
       .credentialsProvider(credentials)
-      .endpointOverride(endpoint)
+      .endpointOverride(uri)
       .build()
+
+  implicit val snsClient: SnsClient =
+    createClientWithEndpoint(localStackEndpoint)
 
   def createTopicName: String =
     randomAlphanumeric()

--- a/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SNS.scala
@@ -1,7 +1,11 @@
 package weco.messaging.fixtures
 
 import software.amazon.awssdk.services.sns.SnsClient
-import software.amazon.awssdk.services.sns.model.{CreateTopicRequest, DeleteTopicRequest, SubscribeRequest}
+import software.amazon.awssdk.services.sns.model.{
+  CreateTopicRequest,
+  DeleteTopicRequest,
+  SubscribeRequest
+}
 import weco.fixtures._
 import weco.json.JsonUtil._
 import weco.messaging.fixtures.SQS.Queue

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -34,7 +34,7 @@ trait SQS
 
   import SQS._
 
-  private val sqsInternalEndpointUrl = s"http://sqs:$port"
+  private val sqsInternalEndpointUrl = s"http://sqs:$localStackPort"
 
   def endpoint(queue: Queue) =
     s"aws-sqs://${queue.name}?amazonSQSEndpoint=$sqsInternalEndpointUrl&accessKey=&secretKey="
@@ -44,7 +44,7 @@ trait SQS
       .builder()
       .region(region)
       .credentialsProvider(credentials)
-      .endpointOverride(endpoint)
+      .endpointOverride(localStackEndpoint)
       .build()
 
   private def setQueueAttribute(

--- a/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
@@ -1,17 +1,20 @@
 package weco.messaging.sns
 
+import org.scalatest.EitherValues
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.services.sns.model.SnsException
+import weco.errors.RetryableError
+import weco.messaging.MessageSenderError
 import weco.messaging.fixtures.SNS
 
-import scala.util.{Failure, Success}
+import java.net.URI
 
 class SNSMessageSenderTest
     extends AnyFunSpec
     with Matchers
     with SNS
+    with EitherValues
     with Eventually
     with IntegrationPatience {
   it("sends messages to SNS") {
@@ -21,7 +24,7 @@ class SNSMessageSenderTest
       sender.send("hello world")(
         subject = "Sent from SNSMessageSenderTest",
         destination = SNSConfig(topic.arn)
-      ) shouldBe Success(())
+      ) shouldBe Right(())
 
       eventually {
         listMessagesReceivedFromSns(topic) shouldBe Seq("hello world")
@@ -29,7 +32,7 @@ class SNSMessageSenderTest
     }
   }
 
-  it("fails if it cannot send to SNS") {
+  it("fails if the topic doesn't exist") {
     val sender = new SNSIndividualMessageSender(snsClient)
 
     val result = sender.send("hello world")(
@@ -37,9 +40,36 @@ class SNSMessageSenderTest
       destination = SNSConfig(topicArn = "arn::doesnotexist")
     )
 
-    result shouldBe a[Failure[_]]
-    val err = result.failed.get
-    err shouldBe a[SnsException]
-    err.getMessage should startWith("Topic does not exist")
+    result.left.value shouldBe a[MessageSenderError.DestinationDoesNotExist]
+  }
+
+  it("fails with a retryable error if it can't connect to SNS") {
+    val wrongPortClient = createClientWithEndpoint(new URI(s"http://localhost:${localStackPort + 1}"))
+
+    val sender = new SNSIndividualMessageSender(wrongPortClient)
+
+    val result = sender.send("hello world")(
+      subject = "Sent from SNSMessageSenderTest",
+      destination = SNSConfig(topicArn = "arn::doesnotexist")
+    )
+
+    val err = result.left.value
+    err shouldBe a[MessageSenderError.UnknownError]
+    err shouldBe a[RetryableError]
+  }
+
+  it("fails with a retryable error if it can't resolve the SNS endpoint") {
+    val unresolvableClient = createClientWithEndpoint(new URI(s"http://this-cannot-be-resolved.nope"))
+
+    val sender = new SNSIndividualMessageSender(unresolvableClient)
+
+    val result = sender.send("hello world")(
+      subject = "Sent from SNSMessageSenderTest",
+      destination = SNSConfig(topicArn = "arn::doesnotexist")
+    )
+
+    val err = result.left.value
+    err shouldBe a[MessageSenderError.UnknownError]
+    err shouldBe a[RetryableError]
   }
 }

--- a/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sns/SNSMessageSenderTest.scala
@@ -44,7 +44,8 @@ class SNSMessageSenderTest
   }
 
   it("fails with a retryable error if it can't connect to SNS") {
-    val wrongPortClient = createClientWithEndpoint(new URI(s"http://localhost:${localStackPort + 1}"))
+    val wrongPortClient = createClientWithEndpoint(
+      new URI(s"http://localhost:${localStackPort + 1}"))
 
     val sender = new SNSIndividualMessageSender(wrongPortClient)
 
@@ -59,7 +60,8 @@ class SNSMessageSenderTest
   }
 
   it("fails with a retryable error if it can't resolve the SNS endpoint") {
-    val unresolvableClient = createClientWithEndpoint(new URI(s"http://this-cannot-be-resolved.nope"))
+    val unresolvableClient =
+      createClientWithEndpoint(new URI(s"http://this-cannot-be-resolved.nope"))
 
     val sender = new SNSIndividualMessageSender(unresolvableClient)
 

--- a/storage/src/main/scala/weco/storage/RetryOps.scala
+++ b/storage/src/main/scala/weco/storage/RetryOps.scala
@@ -1,6 +1,7 @@
 package weco.storage
 
 import grizzled.slf4j.Logging
+import weco.errors.RetryableError
 
 import scala.annotation.tailrec
 

--- a/storage/src/main/scala/weco/storage/StorageError.scala
+++ b/storage/src/main/scala/weco/storage/StorageError.scala
@@ -4,15 +4,6 @@ sealed trait StorageError {
   val e: Throwable
 }
 
-/** Used to mark errors that can be retried.
-  *
-  * For example, a DynamoDB update() might fail with a ConditionalCheckFailed
-  * exception if two processes try to write at the same time.  The operation
-  * can be retried and will likely succeed.
-  *
-  */
-trait RetryableError
-
 sealed trait CodecError
 sealed trait BackendError
 

--- a/storage/src/main/scala/weco/storage/azure/AzureStorageErrors.scala
+++ b/storage/src/main/scala/weco/storage/azure/AzureStorageErrors.scala
@@ -1,12 +1,8 @@
 package weco.storage.azure
 
 import com.azure.storage.blob.models.BlobStorageException
-import weco.storage.{
-  DoesNotExistError,
-  ReadError,
-  RetryableError,
-  StoreReadError
-}
+import weco.errors.RetryableError
+import weco.storage.{DoesNotExistError, ReadError, StoreReadError}
 
 object AzureStorageErrors {
   val readErrors: PartialFunction[Throwable, ReadError] = {

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -3,7 +3,13 @@ package weco.storage.s3
 import com.amazonaws.SdkClientException
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import weco.errors.RetryableError
-import weco.storage.{DoesNotExistError, ReadError, StoreReadError, StoreWriteError, WriteError}
+import weco.storage.{
+  DoesNotExistError,
+  ReadError,
+  StoreReadError,
+  StoreWriteError,
+  WriteError
+}
 
 import java.net.SocketTimeoutException
 
@@ -19,7 +25,8 @@ object S3Errors {
         if exc.getMessage.startsWith("The specified bucket is not valid") =>
       StoreReadError(exc)
 
-    case exc: SdkClientException if exc.getMessage.startsWith("Unable to execute HTTP request") =>
+    case exc: SdkClientException
+        if exc.getMessage.startsWith("Unable to execute HTTP request") =>
       new StoreReadError(exc) with RetryableError
 
     case exc: SocketTimeoutException =>

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -1,14 +1,10 @@
 package weco.storage.s3
 
-import java.net.SocketTimeoutException
-
 import com.amazonaws.services.s3.model.AmazonS3Exception
-import weco.storage.{
-  DoesNotExistError,
-  ReadError,
-  RetryableError,
-  StoreReadError
-}
+import weco.errors.RetryableError
+import weco.storage.{DoesNotExistError, ReadError, StoreReadError, StoreWriteError, WriteError}
+
+import java.net.SocketTimeoutException
 
 object S3Errors {
   val readErrors: PartialFunction[Throwable, ReadError] = {
@@ -26,5 +22,12 @@ object S3Errors {
       new StoreReadError(exc) with RetryableError
 
     case exc => StoreReadError(exc)
+  }
+
+  val writeErrors: PartialFunction[Throwable, WriteError] = {
+    case exc: AmazonS3Exception if exc.getStatusCode == 500 =>
+      new StoreWriteError(exc) with RetryableError
+
+    case exc => StoreWriteError(exc)
   }
 }

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -1,5 +1,6 @@
 package weco.storage.s3
 
+import com.amazonaws.SdkClientException
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import weco.errors.RetryableError
 import weco.storage.{DoesNotExistError, ReadError, StoreReadError, StoreWriteError, WriteError}
@@ -17,6 +18,9 @@ object S3Errors {
     case exc: AmazonS3Exception
         if exc.getMessage.startsWith("The specified bucket is not valid") =>
       StoreReadError(exc)
+
+    case exc: SdkClientException if exc.getMessage.startsWith("Unable to execute HTTP request") =>
+      new StoreReadError(exc) with RetryableError
 
     case exc: SocketTimeoutException =>
       new StoreReadError(exc) with RetryableError

--- a/storage/src/main/scala/weco/storage/store/VersionedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/VersionedStore.scala
@@ -1,6 +1,7 @@
 package weco.storage.store
 
 import grizzled.slf4j.Logging
+import weco.errors.RetryableError
 import weco.storage._
 import weco.storage.maxima.Maxima
 

--- a/storage/src/main/scala/weco/storage/store/dynamo/DynamoWritable.scala
+++ b/storage/src/main/scala/weco/storage/store/dynamo/DynamoWritable.scala
@@ -5,7 +5,8 @@ import org.scanamo.syntax._
 import org.scanamo.{ConditionNotMet, DynamoFormat, Scanamo, Table}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
-import weco.storage.{Identified, RetryableError, StoreWriteError, Version}
+import weco.errors.RetryableError
+import weco.storage.{Identified, StoreWriteError, Version}
 import weco.storage.dynamo.{DynamoHashEntry, DynamoHashRangeEntry}
 import weco.storage.store.Writable
 

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
 import com.amazonaws.services.s3.transfer.{TransferManagerBuilder, Upload}
 import weco.storage._
-import weco.storage.s3.S3ObjectLocation
+import weco.storage.s3.{S3Errors, S3ObjectLocation}
 import weco.storage.store.Writable
 import weco.storage.streaming.InputStreamWithLength
 
@@ -109,6 +109,6 @@ trait S3StreamWritable
       case exc: SdkClientException
           if exc.getMessage.startsWith("More data read than expected") =>
         IncorrectStreamLengthError(exc)
-      case _ => StoreWriteError(throwable)
+      case _ => S3Errors.writeErrors(throwable)
     }
 }

--- a/storage/src/main/scala/weco/storage/tags/s3/S3Tags.scala
+++ b/storage/src/main/scala/weco/storage/tags/s3/S3Tags.scala
@@ -57,12 +57,8 @@ class S3Tags(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
         )
       )
     } match {
-      case Success(_) => Right(tags)
-
-      case Failure(exc: AmazonS3Exception) if exc.getStatusCode == 500 =>
-        Left(new StoreWriteError(exc) with RetryableError)
-
-      case Failure(err) => Left(StoreWriteError(err))
+      case Success(_)   => Right(tags)
+      case Failure(err) => Left(S3Errors.writeErrors(err))
     }
   }
 }

--- a/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -5,7 +5,11 @@ import java.net.URL
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{S3ObjectInputStream, S3ObjectSummary}
 import com.azure.storage.blob.BlobServiceClient
-import com.azure.storage.blob.models.{BlobRange, BlobStorageException, BlockListType}
+import com.azure.storage.blob.models.{
+  BlobRange,
+  BlobStorageException,
+  BlockListType
+}
 import com.azure.storage.blob.specialized.{BlobInputStream, BlockBlobClient}
 import grizzled.slf4j.Logging
 import org.apache.commons.io.IOUtils
@@ -17,7 +21,11 @@ import weco.storage.StoreWriteError
 import weco.storage.azure.AzureBlobLocation
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.services.azure.AzureSizeFinder
-import weco.storage.transfer.{TransferNoOp, TransferOverwriteFailure, TransferSourceFailure}
+import weco.storage.transfer.{
+  TransferNoOp,
+  TransferOverwriteFailure,
+  TransferSourceFailure
+}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -5,29 +5,19 @@ import java.net.URL
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{S3ObjectInputStream, S3ObjectSummary}
 import com.azure.storage.blob.BlobServiceClient
-import com.azure.storage.blob.models.{
-  BlobRange,
-  BlobStorageException,
-  BlockListType
-}
+import com.azure.storage.blob.models.{BlobRange, BlobStorageException, BlockListType}
 import com.azure.storage.blob.specialized.{BlobInputStream, BlockBlobClient}
 import grizzled.slf4j.Logging
 import org.apache.commons.io.IOUtils
-import weco.storage.azure.AzureBlobLocation
+import weco.errors.RetryableError
 import weco.storage.models.ByteRange
-import weco.storage.s3.S3ObjectLocation
-import weco.storage.services.azure.AzureSizeFinder
 import weco.storage.services.s3.{S3RangedReader, S3Uploader}
 import weco.storage.transfer._
-import weco.storage.{RetryableError, StoreWriteError}
+import weco.storage.StoreWriteError
 import weco.storage.azure.AzureBlobLocation
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.services.azure.AzureSizeFinder
-import weco.storage.transfer.{
-  TransferNoOp,
-  TransferOverwriteFailure,
-  TransferSourceFailure
-}
+import weco.storage.transfer.{TransferNoOp, TransferOverwriteFailure, TransferSourceFailure}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/storage/src/test/scala/weco/storage/RetryOpsTest.scala
+++ b/storage/src/test/scala/weco/storage/RetryOpsTest.scala
@@ -3,6 +3,7 @@ package weco.storage
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.errors.RetryableError
 
 class RetryOpsTest extends AnyFunSpec with Matchers with EitherValues {
   import RetryOps._

--- a/storage/src/test/scala/weco/storage/azure/AzureStorageErrorsTest.scala
+++ b/storage/src/test/scala/weco/storage/azure/AzureStorageErrorsTest.scala
@@ -2,7 +2,7 @@ package weco.storage.azure
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.storage.RetryableError
+import weco.errors.RetryableError
 
 class AzureStorageErrorsTest extends AnyFunSpec with Matchers {
   it("marks a timeout as a retriable error") {

--- a/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
+++ b/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
@@ -45,25 +45,23 @@ trait S3Fixtures
 
   import S3Fixtures._
 
-  implicit val s3Client: AmazonS3 =
+  val s3Port = 33333
+
+  def createS3ClientWithEndpoint(endpoint: String): AmazonS3 =
     AmazonS3ClientBuilder
       .standard()
       .withCredentials(new AWSStaticCredentialsProvider(
         new BasicAWSCredentials("accessKey1", "verySecretKey1")))
       .withPathStyleAccessEnabled(true)
       .withEndpointConfiguration(
-        new EndpointConfiguration("http://localhost:33333", "localhost"))
+        new EndpointConfiguration(endpoint, "localhost"))
       .build()
 
+  implicit val s3Client: AmazonS3 =
+    createS3ClientWithEndpoint(s"http://localhost:$s3Port")
+
   val brokenS3Client: AmazonS3 =
-    AmazonS3ClientBuilder
-      .standard()
-      .withCredentials(new AWSStaticCredentialsProvider(
-        new BasicAWSCredentials("nope", "nope")))
-      .withPathStyleAccessEnabled(true)
-      .withEndpointConfiguration(
-        new EndpointConfiguration("http://nope.nope", "nope"))
-      .build()
+    createS3ClientWithEndpoint("http://nope.nope")
 
   def withLocalS3Bucket[R]: Fixture[Bucket, R] =
     fixture[Bucket, R](

--- a/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
+++ b/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
@@ -7,11 +7,7 @@ import weco.errors.RetryableError
 import weco.fixtures.{RandomGenerators, TestWith}
 import weco.storage.models.ByteRange
 import weco.storage.streaming.Codec
-import weco.storage.{
-  DoesNotExistError,
-  ReadError,
-  StoreReadError
-}
+import weco.storage.{DoesNotExistError, ReadError, StoreReadError}
 
 trait LargeStreamReaderTestCases[Ident, Namespace]
     extends AnyFunSpec

--- a/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
+++ b/storage/src/test/scala/weco/storage/services/LargeStreamReaderTestCases.scala
@@ -3,13 +3,13 @@ package weco.storage.services
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.errors.RetryableError
 import weco.fixtures.{RandomGenerators, TestWith}
 import weco.storage.models.ByteRange
 import weco.storage.streaming.Codec
 import weco.storage.{
   DoesNotExistError,
   ReadError,
-  RetryableError,
   StoreReadError
 }
 

--- a/storage/src/test/scala/weco/storage/store/VersionedStoreRaceConditionsTest.scala
+++ b/storage/src/test/scala/weco/storage/store/VersionedStoreRaceConditionsTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
+import weco.errors.RetryableError
 import weco.storage._
 import weco.storage.maxima.Maxima
 import weco.storage.maxima.memory.MemoryMaxima

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoWritableTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoWritableTestCases.scala
@@ -8,7 +8,8 @@ import software.amazon.awssdk.services.dynamodb.model.{
   DynamoDbException,
   ResourceNotFoundException
 }
-import weco.storage.{RetryableError, Version}
+import weco.errors.RetryableError
+import weco.storage.Version
 import weco.storage.dynamo.DynamoEntry
 import weco.storage.fixtures.DynamoFixtures
 import weco.storage.fixtures.DynamoFixtures.Table

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
@@ -81,7 +81,8 @@ class S3StreamReadableTest
   }
 
   it("retries if it's unable to connect to S3") {
-    val wrongPortClient = createS3ClientWithEndpoint(s"http://localhost:${s3Port + 1}")
+    val wrongPortClient =
+      createS3ClientWithEndpoint(s"http://localhost:${s3Port + 1}")
     val spyClient = spy(wrongPortClient)
 
     val retries = 4
@@ -97,7 +98,8 @@ class S3StreamReadableTest
   }
 
   it("retries if it can't resolve the S3 endpoint") {
-    val wrongPortClient = createS3ClientWithEndpoint(s"http://this-cannot-be-resolved.nope")
+    val wrongPortClient =
+      createS3ClientWithEndpoint(s"http://this-cannot-be-resolved.nope")
     val spyClient = spy(wrongPortClient)
 
     val retries = 4

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
@@ -79,4 +79,36 @@ class S3StreamReadableTest
 
     verify(mockClient, times(retries)).getObject(location.bucket, location.key)
   }
+
+  it("retries if it's unable to connect to S3") {
+    val wrongPortClient = createS3ClientWithEndpoint(s"http://localhost:${s3Port + 1}")
+    val spyClient = spy(wrongPortClient)
+
+    val retries = 4
+    val readable = createS3ReadableWith(spyClient, retries = retries)
+
+    withLocalS3Bucket { bucket =>
+      val location = createS3ObjectLocationWith(bucket)
+
+      readable.get(location).left.value shouldBe a[StoreReadError]
+
+      verify(spyClient, times(retries)).getObject(location.bucket, location.key)
+    }
+  }
+
+  it("retries if it can't resolve the S3 endpoint") {
+    val wrongPortClient = createS3ClientWithEndpoint(s"http://this-cannot-be-resolved.nope")
+    val spyClient = spy(wrongPortClient)
+
+    val retries = 4
+    val readable = createS3ReadableWith(spyClient, retries = retries)
+
+    withLocalS3Bucket { bucket =>
+      val location = createS3ObjectLocationWith(bucket)
+
+      readable.get(location).left.value shouldBe a[StoreReadError]
+
+      verify(spyClient, times(retries)).getObject(location.bucket, location.key)
+    }
+  }
 }

--- a/typesafe_app/src/main/scala/weco/errors/RetryableError.scala
+++ b/typesafe_app/src/main/scala/weco/errors/RetryableError.scala
@@ -1,0 +1,10 @@
+package weco.errors
+
+/** Used to mark errors that can be retried.
+  *
+  * For example, a DynamoDB update() might fail with a ConditionalCheckFailed
+  * exception if two processes try to write at the same time.  The operation
+  * can be retried and will likely succeed.
+  *
+  */
+trait RetryableError


### PR DESCRIPTION
The release note explains the broad strokes.

The size of the diff is because I moved `RetryableError` into `typesafe_app` (which is really becoming a sort of "core" library), so we'd have a single definition rather than multiple ones flying around. 

For https://github.com/wellcomecollection/platform/issues/5419