### PR TITLE
Log a warning whenever we delete messages with a DeterministicFailure; rename result types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release tidies up the `Result` types to reflect the desired behaviour (TerminalFailure, RetryableFailure, Successful) rather than their properties (Deterministic, NonDeterministic).
+This will need to be changed in downstream code.
+
+Additionally, the full body of any message deleted as a TerminalFailure will be logged, to make it easier to retry/redrive these messages later.

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -1,26 +1,36 @@
 # messaging
 
+This library has classes for inter-app messaging.
 
-Messaging libraries for inter-service communication.
+Most of our services form a pipeline: an app receives a message, does some work, then sends another message to the next app in line.
+This continues until the work is finished.
 
-Includes:
--   `SQSStream`: An Akka streams-backed class for processing messages from an SQS queue.
--   `SNSWriter`: A strongly typed client that allows sending notifications to SNS.
--   `MessageStream` and associated pieces: a messaging stack that allows publishing via SNS/SQS, or storing pointers to objects in S3 if the messages are too large.
+<img src="pipeline.svg">
 
-These libraries are used as part of the [Wellcome Digital Platform][platform].
+This is the [pub/sub (publish-subscribe) pattern](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern).
 
-[platform]: https://github.com/wellcomecollection/platform
+We use two AWS primitives for messaging:
 
+*   To **receive messages**, apps poll an *SQS queue*. (SQS = Simple Queuing Service)
+*   To **send messages**, apps sends notification to an *SNS topic*. (SNS = Simple Notification Service)
 
-## Installation
+## Key components
 
-```scala
-libraryDependencies ++= Seq(
-  "weco" %% "messaging" % "<LATEST_VERSION>"
-)
-```
+*   To **receive messages** from SQS, we have two components, both of which provide an Akka stream for processing from SQS:
 
-`messaging` is published for Scala 2.11 and Scala 2.12.
+    -   `SQSStream` is used in the [catalogue pipeline].
+        It provides low-level, fine-grained control over the stream, e.g. allowing callers to process multiple messages together.
 
-Read [the changelog](CHANGELOG.md) to find the latest version.
+    -   `AlpakkaSQSWorker` is used in the [storage service].
+        It provides a simpler, one-message-at-a-time interface.
+
+    That we have two components is a historical accident.
+    In an ideal world, we might have a single component that's used in both projects – but at this point, both are well tested in their specific context, and trying to refactor one of them away would be a significant risk.
+
+*   To **send messages**, we have two components, both based on the `MessageSender` trait:
+
+    -   `MemoryMessageSender` is an in-memory implementation, meant for easy testing of apps that use the `MessageSender` functionality
+    -   `SNSMessageSender` sends notifications to SNS, meant for live applications
+
+[catalogue pipeline]: https://github.com/wellcomecollection/catalogue-pipeline
+[storage service]: https://github.com/wellcomecollection/storage-service

--- a/messaging/pipeline.svg
+++ b/messaging/pipeline.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 60">
+  <defs>
+    <style>
+      .app {
+        stroke: #D45B07;
+        stroke-width: 1;
+        fill: rgba(212, 91, 7, 0.3);
+      }
+
+      .topic, .queue {
+        stroke: #FF4F8B;
+        stroke-width: 1;
+        fill: rgba(255, 79, 139, 0.3);
+      }
+
+      text {
+        fill: black;
+        font-size: 13px;
+        stroke: none;
+        text-anchor: middle;
+        dominant-baseline: middle;
+        font-family: sans-serif;
+      }
+
+      line {
+        stroke: #222;
+        stroke-width: 1.5;
+        stroke-linecap: round;
+      }
+    </style>
+  </defs>
+
+  <rect class="app" x="10" y="10" width="40" height="40" rx="10"/>
+  <rect class="app" x="115" y="10" width="40" height="40" rx="10"/>
+  <rect class="app" x="220" y="10" width="40" height="40" rx="10"/>
+  <rect class="app" x="325" y="10" width="40" height="40" rx="10"/>
+
+  <text x="30" y="30">app</text>
+  <text x="135" y="30">app</text>
+  <text x="240" y="30">app</text>
+  <text x="345" y="30">app</text>
+
+  <svg x="0">
+    <line x1="57" y1="30" x2="105" y2="30"/>
+    <line x1="107" y1="30" x2="101" y2="33"/>
+    <line x1="107" y1="30" x2="101" y2="27"/>
+  </svg>
+
+  <svg x="105">
+    <line x1="57" y1="30" x2="105" y2="30"/>
+    <line x1="107" y1="30" x2="101" y2="33"/>
+    <line x1="107" y1="30" x2="101" y2="27"/>
+  </svg>
+
+  <svg x="210">
+    <line x1="57" y1="30" x2="105" y2="30"/>
+    <line x1="107" y1="30" x2="101" y2="33"/>
+    <line x1="107" y1="30" x2="101" y2="27"/>
+  </svg>
+</svg>

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -59,17 +59,15 @@ class AlpakkaSQSWorker[Work, Summary](
   // any reason, we log it (including hte full body) and delete it from the
   // original queue.  This will flag it for human inspection/intervention.
   //
-  // This is balancing several concerns:
+  // This class is used in the storage service, where we want to be careful
+  // when things go wrong.  When there is an unexpected failure, we want to
+  // give up immediately and wait for human intervention, rather than plough
+  // on and make things worse.
   //
-  //    - This class is used in the storage service, where we want to be
-  //      conservative when things go wrong.  When there is an unexpected failure,
-  //      we want to give up immediately and wait for human intervention, rather
-  //      than plough on and make things worse.
-  //
-  //    - Ideally we'd put the message on a DLQ, where it could be easily redriven --
-  //      but there's no way to automatically put a received message on a DLQ.
-  //      We could send to the queue manually, but that introduces other possible
-  //      failure modes and would need us to update IAM permissions on all our services.
+  // Ideally we'd put the message on a DLQ, where it could be easily redriven --
+  // but there's no good way to put a received message on a DLQ.  We could send
+  // to the queue manually, but that introduces other possible failure modes and
+  // would need us to update IAM permissions on all our services.
   //
   val failureAction: SQSAction = (message: SQSMessage) => {
 

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -73,7 +73,10 @@ class AlpakkaSQSWorker[Work, Summary](
   //      can't send a failure message to SNS (see https://github.com/wellcomecollection/platform/issues/5419)
   //
   val failureAction: SQSAction = (message: SQSMessage) => {
-    warn(s"Deleting failed message $message")
+
+    // Note: this log includes the full body of the message, so if something goes wrong
+    // further down, we at least have that.
+    warn(s"Deleting and DLQ'ing failed message $message")
 
     // Note: this is the best way I can think of to send a message directly to the
     // DLQ; I can't find a way to a better way to modify a message on a queue that

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -1,12 +1,12 @@
 package weco.messaging.sqsworker.alpakka
 
 import akka.actor.ActorSystem
-import akka.stream.alpakka.sqs
 import akka.stream.alpakka.sqs.MessageAction
 import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
+import grizzled.slf4j.Logging
 import io.circe.Decoder
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
+import software.amazon.awssdk.services.sqs.model.{SendMessageRequest, Message => SQSMessage}
 import weco.json.JsonUtil.fromJson
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.worker.models.Result
@@ -28,7 +28,8 @@ class AlpakkaSQSWorker[Work, Summary](
   val wd: Decoder[Work],
   sc: SqsAsyncClient,
   val metrics: Metrics[Future])
-    extends AkkaWorker[SQSMessage, Work, Summary, MessageAction] {
+  extends AkkaWorker[SQSMessage, Work, Summary, MessageAction]
+    with Logging {
   override protected val metricsNamespace: String =
     config.metricsConfig.namespace
 
@@ -38,7 +39,7 @@ class AlpakkaSQSWorker[Work, Summary](
       work <- fromJson[Work](notification.body)
     } yield work
 
-  type SQSAction = SQSMessage => sqs.MessageAction
+  type SQSAction = SQSMessage => MessageAction
 
   val parallelism: Int = config.sqsConfig.parallelism
   val source = SqsSource(config.sqsConfig.queueUrl)
@@ -48,6 +49,44 @@ class AlpakkaSQSWorker[Work, Summary](
     MessageAction
       .changeMessageVisibility(message, visibilityTimeout = 0)
 
-  val completedAction: SQSAction = (message: SQSMessage) =>
+  val successfulAction: SQSAction = (message: SQSMessage) =>
     MessageAction.delete(message)
+
+  // We're deliberately quite conservative here -- if a message fails for
+  // any reason, we move it to the DLQ and delete it from the original queue.
+  // This will flag it for human inspection/intervention.
+  //
+  // This is balancing several concerns:
+  //
+  //    - This class is used in the storage service, where we want to be
+  //      conservative when things go wrong.  When there is an unexpected failure,
+  //      we want to give up immediately and wait for human intervention, rather
+  //      than plough on and make things worse.
+  //
+  //    - Putting the message on a DLQ means it should show up in our DLQ alerting,
+  //      and can be easily redriven if the failure was flaky/transient.
+  //
+  //      This may help us catch issues that would otherwise be lost, e.g. if an app
+  //      can't send a failure message to SNS (see https://github.com/wellcomecollection/platform/issues/5419)
+  //
+  val failureAction: SQSAction = (message: SQSMessage) => {
+    warn(s"Deleting failed message $message")
+
+    // Note: this is the best way I can think of to send a message directly to the
+    // DLQ; I can't find a way to a better way to modify a message on a queue that
+    // doesn't either (1) delete it entirely or (2) make it available to other consumers.
+    //
+    // The DLQ URL is based on our standard suffix for DLQs; see
+    // https://github.com/wellcomecollection/terraform-aws-sqs/blob/a3bb6892b483c9396df594230c96a16524d57c69/queue/main.tf#L22-L24
+    //
+    // TODO: Make the DLQ URL a configurable parameter.
+    sc.sendMessage(
+      SendMessageRequest.builder()
+        .queueUrl(config.sqsConfig.queueUrl + "_dlq")
+        .messageBody(message.body())
+        .build()
+    ).get
+
+    MessageAction.delete(message)
+  }
 }

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -56,8 +56,8 @@ class AlpakkaSQSWorker[Work, Summary](
     MessageAction.delete(message)
 
   // We're deliberately quite conservative here -- if a message fails for
-  // any reason, we move it to the DLQ and delete it from the original queue.
-  // This will flag it for human inspection/intervention.
+  // any reason, we log it (including hte full body) and delete it from the
+  // original queue.  This will flag it for human inspection/intervention.
   //
   // This is balancing several concerns:
   //
@@ -66,34 +66,16 @@ class AlpakkaSQSWorker[Work, Summary](
   //      we want to give up immediately and wait for human intervention, rather
   //      than plough on and make things worse.
   //
-  //    - Putting the message on a DLQ means it should show up in our DLQ alerting,
-  //      and can be easily redriven if the failure was flaky/transient.
-  //
-  //      This may help us catch issues that would otherwise be lost, e.g. if an app
-  //      can't send a failure message to SNS (see https://github.com/wellcomecollection/platform/issues/5419)
+  //    - Ideally we'd put the message on a DLQ, where it could be easily redriven --
+  //      but there's no way to automatically put a received message on a DLQ.
+  //      We could send to the queue manually, but that introduces other possible
+  //      failure modes and would need us to update IAM permissions on all our services.
   //
   val failureAction: SQSAction = (message: SQSMessage) => {
 
     // Note: this log includes the full body of the message, so if something goes wrong
-    // further down, we at least have that.
-    warn(s"Deleting and DLQ'ing failed message $message")
-
-    // Note: this is the best way I can think of to send a message directly to the
-    // DLQ; I can't find a way to a better way to modify a message on a queue that
-    // doesn't either (1) delete it entirely or (2) make it available to other consumers.
-    //
-    // The DLQ URL is based on our standard suffix for DLQs; see
-    // https://github.com/wellcomecollection/terraform-aws-sqs/blob/a3bb6892b483c9396df594230c96a16524d57c69/queue/main.tf#L22-L24
-    //
-    // TODO: Make the DLQ URL a configurable parameter.
-    sc.sendMessage(
-        SendMessageRequest
-          .builder()
-          .queueUrl(config.sqsConfig.queueUrl + "_dlq")
-          .messageBody(message.body())
-          .build()
-      )
-      .get
+    // further down, we can get it later.
+    warn(s"Deleting failed message $message")
 
     MessageAction.delete(message)
   }

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -6,10 +6,7 @@ import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import software.amazon.awssdk.services.sqs.model.{
-  SendMessageRequest,
-  Message => SQSMessage
-}
+import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
 import weco.json.JsonUtil.fromJson
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.worker.models.Result

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -6,7 +6,10 @@ import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import software.amazon.awssdk.services.sqs.model.{SendMessageRequest, Message => SQSMessage}
+import software.amazon.awssdk.services.sqs.model.{
+  SendMessageRequest,
+  Message => SQSMessage
+}
 import weco.json.JsonUtil.fromJson
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.worker.models.Result
@@ -28,7 +31,7 @@ class AlpakkaSQSWorker[Work, Summary](
   val wd: Decoder[Work],
   sc: SqsAsyncClient,
   val metrics: Metrics[Future])
-  extends AkkaWorker[SQSMessage, Work, Summary, MessageAction]
+    extends AkkaWorker[SQSMessage, Work, Summary, MessageAction]
     with Logging {
   override protected val metricsNamespace: String =
     config.metricsConfig.namespace
@@ -81,11 +84,13 @@ class AlpakkaSQSWorker[Work, Summary](
     //
     // TODO: Make the DLQ URL a configurable parameter.
     sc.sendMessage(
-      SendMessageRequest.builder()
-        .queueUrl(config.sqsConfig.queueUrl + "_dlq")
-        .messageBody(message.body())
-        .build()
-    ).get
+        SendMessageRequest
+          .builder()
+          .queueUrl(config.sqsConfig.queueUrl + "_dlq")
+          .messageBody(message.body())
+          .build()
+      )
+      .get
 
     MessageAction.delete(message)
   }

--- a/messaging/src/main/scala/weco/messaging/worker/AkkaWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/AkkaWorker.scala
@@ -19,9 +19,6 @@ trait AkkaWorker[Message, Work, Summary, Action]
   protected val source: MessageSource
   protected val sink: MessageSink
 
-  protected val retryAction: MessageAction
-  protected val completedAction: MessageAction
-
   def start: Future[Done] =
     source
       .mapAsyncUnordered(parallelism)(process)

--- a/messaging/src/main/scala/weco/messaging/worker/Worker.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/Worker.scala
@@ -58,8 +58,7 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
   /** Records metrics about the work that's just been completed; in particular the
     * outcome and the duration.
     */
-  private def recordEnd(startTime: Instant,
-                        result: Result[_]): Future[Unit] = {
+  private def recordEnd(startTime: Instant, result: Result[_]): Future[Unit] = {
     val futures = Seq(
       metrics.incrementCount(s"$metricsNamespace/${result.name}"),
       metrics
@@ -68,10 +67,11 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
 
     Future
       .sequence(futures)
-      .map(_ => () )
-      .recover { case e =>
-        warn(s"Unable to record metrics: $e")
-        ()
+      .map(_ => ())
+      .recover {
+        case e =>
+          warn(s"Unable to record metrics: $e")
+          ()
       }
   }
 

--- a/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
@@ -10,7 +10,7 @@ sealed trait Result[Summary] {
     s"$name: ${summary.getOrElse("<no-summary>")}"
 }
 
-// An operation that failed, and can't be retried.
+// An operation that failed, and which the caller thinks can't be retried.
 //
 // e.g. trying to write an object to a non-existent S3 bucket.  This will always
 // fail, no matter how often we try.
@@ -19,7 +19,7 @@ case class TerminalFailure[Summary](
   summary: Option[Summary] = Option.empty[Summary]
 ) extends Result[Summary]
 
-// An operation that failed, and can be retried.
+// An operation that failed, and which the caller knows can be retried.
 //
 // e.g. a 500 error when trying to write an object to S3.  This will usually
 // succeed if we try again after a short pause.

--- a/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
@@ -10,20 +10,32 @@ sealed trait Result[Summary] {
     s"$name: ${summary.getOrElse("<no-summary>")}"
 }
 
-case class DeterministicFailure[Summary](
+// An operation that failed, and can't be retried.
+//
+// e.g. trying to write an object to a non-existent S3 bucket.  This will always
+// fail, no matter how often we try.
+case class TerminalFailure[Summary](
   failure: Throwable,
   summary: Option[Summary] = Option.empty[Summary]
 ) extends Result[Summary]
 
-case class NonDeterministicFailure[Summary](
+// An operation that failed, and can be retried.
+//
+// e.g. a 500 error when trying to write an object to S3.  This will usually
+// succeed if we try again after a short pause.
+case class RetryableFailure[Summary](
   failure: Throwable,
   summary: Option[Summary] = Option.empty[Summary]
 ) extends Result[Summary]
 
+// An operation that succeeded.
 case class Successful[Summary](
   summary: Option[Summary] = Option.empty[Summary]
 ) extends Result[Summary]
 
+// An operation that couldn't be recorded.
+//
+// TODO: What should we do in this case?  How do we capture the previous result?
 case class MonitoringProcessorFailure[Summary](
   failure: Throwable,
   summary: Option[Summary] = Option.empty[Summary]

--- a/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/models/Result.scala
@@ -32,11 +32,3 @@ case class RetryableFailure[Summary](
 case class Successful[Summary](
   summary: Option[Summary] = Option.empty[Summary]
 ) extends Result[Summary]
-
-// An operation that couldn't be recorded.
-//
-// TODO: What should we do in this case?  How do we capture the previous result?
-case class MonitoringProcessorFailure[Summary](
-  failure: Throwable,
-  summary: Option[Summary] = Option.empty[Summary]
-) extends Result[Summary]

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -124,7 +124,9 @@ trait SQS
     testWith: TestWith[QueuePair, R]): R = {
     val queueName = createQueueName
 
-    withLocalSqsQueue(queueName = s"$queueName-dlq") { dlq =>
+    // This matches the naming convention used by our Terraform module.
+    // See https://github.com/wellcomecollection/terraform-aws-sqs/blob/a3bb6892b483c9396df594230c96a16524d57c69/queue/main.tf#L22-L24
+    withLocalSqsQueue(queueName = s"${queueName}_dlq") { dlq =>
       withLocalSqsQueue(
         queueName = queueName,
         visibilityTimeout = visibilityTimeout) { queue =>

--- a/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
@@ -47,13 +47,17 @@ trait WorkerFixtures {
       extends Worker[MyMessage, MyWork, MySummary, MyExternalMessageAction] {
     val callCounter = new CallCounter()
 
-    override val retryAction: MessageAction =
+    override val retryAction: MyMessage => MyExternalMessageAction =
       _ =>
         MyExternalMessageAction(
           RetryableFailure[MySummary](failure = new Throwable("BOOM!")))
 
-    override val completedAction: MessageAction =
+    override val successfulAction: MyMessage => MyExternalMessageAction =
       _ => MyExternalMessageAction(Successful())
+
+    override val failureAction: MyMessage => MyExternalMessageAction =
+      _ => MyExternalMessageAction(
+        TerminalFailure[MySummary](failure = new Throwable("BOOM!")))
 
     override val doWork =
       (work: MyWork) => createResult(testProcess, callCounter)(ec)(work)

--- a/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
@@ -95,11 +95,6 @@ trait WorkerFixtures {
       failure = new RuntimeException("TerminalFailure"),
       summary = Some("Summary TerminalFailure"))
 
-  val monitoringProcessorFailure = (_: MyWork) =>
-    MonitoringProcessorFailure[MySummary](
-      failure = new RuntimeException("MonitoringProcessorFailure"),
-      summary = Some("Summary MonitoringProcessorFailure"))
-
   val exceptionState = (_: MyWork) => {
     throw new RuntimeException("BOOM")
 

--- a/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
@@ -50,7 +50,7 @@ trait WorkerFixtures {
     override val retryAction: MessageAction =
       _ =>
         MyExternalMessageAction(
-          NonDeterministicFailure[MySummary](failure = new Throwable("BOOM!")))
+          RetryableFailure[MySummary](failure = new Throwable("BOOM!")))
 
     override val completedAction: MessageAction =
       _ => MyExternalMessageAction(Successful())
@@ -77,29 +77,23 @@ trait WorkerFixtures {
       }
   }
 
-  val successful = (_: MyWork) => {
-    Successful[MySummary](
-      Some("Summary Successful")
-    )
-  }
+  val successful = (_: MyWork) =>
+    Successful[MySummary](summary = Some("Summary Successful"))
 
-  val nonDeterministicFailure = (_: MyWork) =>
-    NonDeterministicFailure[MySummary](
-      new RuntimeException("NonDeterministicFailure"),
-      Some("Summary NonDeterministicFailure")
-  )
+  val retryableFailure = (_: MyWork) =>
+    RetryableFailure[MySummary](
+      failure = new RuntimeException("RetryableFailure"),
+      summary = Some("Summary RetryableFailure"))
 
-  val deterministicFailure = (_: MyWork) =>
-    DeterministicFailure[MySummary](
-      new RuntimeException("DeterministicFailure"),
-      Some("Summary DeterministicFailure")
-  )
+  val terminalFailure = (_: MyWork) =>
+    TerminalFailure[MySummary](
+      failure = new RuntimeException("TerminalFailure"),
+      summary = Some("Summary TerminalFailure"))
 
   val monitoringProcessorFailure = (_: MyWork) =>
     MonitoringProcessorFailure[MySummary](
-      new RuntimeException("MonitoringProcessorFailure"),
-      Some("Summary MonitoringProcessorFailure")
-  )
+      failure = new RuntimeException("MonitoringProcessorFailure"),
+      summary = Some("Summary MonitoringProcessorFailure"))
 
   val exceptionState = (_: MyWork) => {
     throw new RuntimeException("BOOM")

--- a/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/worker/WorkerFixtures.scala
@@ -56,8 +56,9 @@ trait WorkerFixtures {
       _ => MyExternalMessageAction(Successful())
 
     override val failureAction: MyMessage => MyExternalMessageAction =
-      _ => MyExternalMessageAction(
-        TerminalFailure[MySummary](failure = new Throwable("BOOM!")))
+      _ =>
+        MyExternalMessageAction(
+          TerminalFailure[MySummary](failure = new Throwable("BOOM!")))
 
     override val doWork =
       (work: MyWork) => createResult(testProcess, callCounter)(ec)(work)

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -105,7 +105,7 @@ class AlpakkaSQSWorkerTest
       }
     }
 
-    it("records a failure if it can't process a message") {
+    it("records a failure if it can't process a message, then DLQs the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -132,7 +132,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, size = 0)
+                  assertQueueHasSize(dlq, size = 1)
                 }
             }
           }
@@ -174,7 +174,7 @@ class AlpakkaSQSWorkerTest
     }
   }
 
-  describe("unparseable messages are deleted and recorded") {
+  describe("unparseable messages are recorded and moved to a DLQ") {
     it("if they're not JSON") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
@@ -198,7 +198,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueEmpty(dlq)
+                  assertQueueHasSize(dlq, size = 1)
                 }
             }
           }
@@ -228,7 +228,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueEmpty(dlq)
+                  assertQueueHasSize(dlq, size = 1)
                 }
             }
           }

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -105,12 +105,11 @@ class AlpakkaSQSWorkerTest
       }
     }
 
-    it(
-      "consumes a message and increments non deterministic failure metrics metrics") {
+    it("records a failure if it can't process a message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
-            withAlpakkaSQSWorker(queue, deterministicFailure, namespace) {
+            withAlpakkaSQSWorker(queue, terminalFailure, namespace) {
               case (worker, _, metrics, callCounter) =>
                 worker.start
 
@@ -123,7 +122,7 @@ class AlpakkaSQSWorkerTest
 
                   assertMetricCount(
                     metrics = metrics,
-                    metricName = s"$namespace/DeterministicFailure",
+                    metricName = s"$namespace/TerminalFailure",
                     expectedCount = 1
                   )
                   assertMetricDurations(
@@ -133,19 +132,18 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, 0)
+                  assertQueueHasSize(dlq, size = 0)
                 }
             }
           }
       }
     }
 
-    it(
-      "retries nonDeterministicFailure 3 times and places the message in the dlq") {
+    it("retries a retryable failure three times, then DLQs the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
-            withAlpakkaSQSWorker(queue, nonDeterministicFailure, namespace) {
+            withAlpakkaSQSWorker(queue, retryableFailure, namespace) {
               case (worker, _, metrics, callCounter) =>
                 worker.start
 
@@ -158,7 +156,7 @@ class AlpakkaSQSWorkerTest
 
                   assertMetricCount(
                     metrics = metrics,
-                    metricName = s"$namespace/NonDeterministicFailure",
+                    metricName = s"$namespace/RetryableFailure",
                     expectedCount = 3
                   )
                   assertMetricDurations(
@@ -168,7 +166,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, 1)
+                  assertQueueHasSize(dlq, size = 1)
                 }
             }
           }
@@ -176,9 +174,8 @@ class AlpakkaSQSWorkerTest
     }
   }
 
-  describe("When a message cannot be parsed") {
-    it(
-      "consumes the message increments failure metrics if the message is not json") {
+  describe("unparseable messages are deleted and recorded") {
+    it("if they're not JSON") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -189,11 +186,9 @@ class AlpakkaSQSWorkerTest
                 sendNotificationToSQS(queue, "not json")
 
                 eventually {
-                  //process.called shouldBe false
-
                   assertMetricCount(
                     metrics = metrics,
-                    metricName = s"$namespace/DeterministicFailure",
+                    metricName = s"$namespace/TerminalFailure",
                     expectedCount = 1
                   )
                   assertMetricDurations(
@@ -205,14 +200,12 @@ class AlpakkaSQSWorkerTest
                   assertQueueEmpty(queue)
                   assertQueueEmpty(dlq)
                 }
-
             }
           }
       }
     }
 
-    it(
-      "consumes the message increments failure metrics if the message is json but not a work") {
+    it("if they can't be parsed") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -220,14 +213,12 @@ class AlpakkaSQSWorkerTest
               case (worker, _, metrics, _) =>
                 worker.start
 
-                sendNotificationToSQS(queue, """{"json" : "but not a work"}""")
+                sendNotificationToSQS(queue, """{"json" : "but not the right format"}""")
 
                 eventually {
-                  //process.called shouldBe false
-
                   assertMetricCount(
                     metrics = metrics,
-                    metricName = s"$namespace/DeterministicFailure",
+                    metricName = s"$namespace/TerminalFailure",
                     expectedCount = 1
                   )
                   assertMetricDurations(
@@ -239,7 +230,6 @@ class AlpakkaSQSWorkerTest
                   assertQueueEmpty(queue)
                   assertQueueEmpty(dlq)
                 }
-
             }
           }
       }

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -62,7 +62,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, 0)
+                  assertQueueEmpty(dlq)
                 }
             }
           }
@@ -98,14 +98,14 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, 0)
+                  assertQueueEmpty(dlq)
                 }
             }
           }
       }
     }
 
-    it("records a failure if it can't process a message, then DLQs the message") {
+    it("records a failure if it can't process a message, then deletes the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -132,14 +132,14 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, size = 1)
+                  assertQueueEmpty(dlq)
                 }
             }
           }
       }
     }
 
-    it("retries a retryable failure three times, then DLQs the message") {
+    it("retries a retryable failure three times, then deletes the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -166,7 +166,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, size = 1)
+                  assertQueueEmpty(dlq)
                 }
             }
           }
@@ -174,7 +174,7 @@ class AlpakkaSQSWorkerTest
     }
   }
 
-  describe("unparseable messages are recorded and moved to a DLQ") {
+  describe("unparseable messages are recorded and deleted") {
     it("if they're not JSON") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
@@ -198,7 +198,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, size = 1)
+                  assertQueueEmpty(dlq)
                 }
             }
           }
@@ -230,7 +230,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueHasSize(dlq, size = 1)
+                  assertQueueEmpty(dlq)
                 }
             }
           }

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -140,7 +140,7 @@ class AlpakkaSQSWorkerTest
       }
     }
 
-    it("retries a retryable failure three times, then deletes the message") {
+    it("retries a retryable failure three times, then DLQs the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
@@ -167,7 +167,7 @@ class AlpakkaSQSWorkerTest
                   )
 
                   assertQueueEmpty(queue)
-                  assertQueueEmpty(dlq)
+                  assertQueueHasSize(dlq, size = 1)
                 }
             }
           }

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -213,7 +213,9 @@ class AlpakkaSQSWorkerTest
               case (worker, _, metrics, _) =>
                 worker.start
 
-                sendNotificationToSQS(queue, """{"json" : "but not the right format"}""")
+                sendNotificationToSQS(
+                  queue,
+                  """{"json" : "but not the right format"}""")
 
                 eventually {
                   assertMetricCount(

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -105,7 +105,8 @@ class AlpakkaSQSWorkerTest
       }
     }
 
-    it("records a failure if it can't process a message, then deletes the message") {
+    it(
+      "records a failure if it can't process a message, then deletes the message") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>


### PR DESCRIPTION
For wellcomecollection/platform#5419; follows #167.

This patch improves the documentation:

* A README for the messaging library, which explains the key components and why we have two classes (SQSStream and AlpakkaSQSWorker) that seem to do the same thing
* Better names for the `Result` classes used by AlpakkaSQSWorker, and brief comments explaining when to use them

And it changes the behaviour for failed messages: when an SQS message fails processing in AlpakkaSQSWorker, we:

1. Log a warning with the complete message (including the body)
2. Remove the message from the original queue

Previously we would just do (1), which was causing messages to disappear without trace.

I think there's more to do, in particular tweaking some of the retry logic, but I'll leave that for a separate patch. Just wrapping my head around this simple change has taken long enough. 😅 