### PR TITLE
Allow retrying some terminal failures, if they're AWS flaking out

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+AlpakkaSQSWorker will retry a `TerminalFailure` if it determines that the error was a flaky error from somewhere in AWS, e.g. a DNS resolution error.

--- a/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -97,12 +97,12 @@ class AlpakkaSQSWorker[Work, Summary](
         true
 
       case exc: SdkClientException
-        if exc.getMessage.startsWith("Unable to execute HTTP request") =>
+          if exc.getMessage.startsWith("Unable to execute HTTP request") =>
         true
 
       case exc: SdkClientException
-        if exc.getMessage.startsWith(
-          "Received an UnknownHostException when attempting to interact with a service") =>
+          if exc.getMessage.startsWith(
+            "Received an UnknownHostException when attempting to interact with a service") =>
         true
 
       case _: SocketTimeoutException => true

--- a/messaging/src/main/scala/weco/messaging/worker/Worker.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/Worker.scala
@@ -21,6 +21,9 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
 
   implicit val ec: ExecutionContext
 
+  protected def isRetryable(t: Throwable): Boolean =
+    false
+
   def process(message: Message): Future[Action] = {
     val startTime = Instant.now()
 
@@ -45,6 +48,15 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
     result match {
       case _: Successful[_]       => successfulAction
       case _: RetryableFailure[_] => retryAction
+
+      // Although in general terminal failures mean a message should be
+      // stopped immediately, we do allow overriding that here in certain
+      // cases.  This allows us to handle certain classes of flaky errors
+      // (e.g. AWS networking issues) in one place, rather than adding code
+      // to recognise them as Retryable everywhere in the stack.
+      case TerminalFailure(t, _) if isRetryable(t) =>
+        retryAction
+
       case _: TerminalFailure[_]  => failureAction
     }
 

--- a/messaging/src/main/scala/weco/messaging/worker/Worker.scala
+++ b/messaging/src/main/scala/weco/messaging/worker/Worker.scala
@@ -57,7 +57,7 @@ trait Worker[Message, Work, Summary, Action] extends Logging {
       case TerminalFailure(t, _) if isRetryable(t) =>
         retryAction
 
-      case _: TerminalFailure[_]  => failureAction
+      case _: TerminalFailure[_] => failureAction
     }
 
   private def log(result: Result[_]): Unit =

--- a/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/weco/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -2,7 +2,11 @@ package weco.messaging.sqsworker.alpakka
 
 import java.net.SocketTimeoutException
 
-import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually, ScalaFutures}
+import org.scalatest.concurrent.{
+  AbstractPatienceConfiguration,
+  Eventually,
+  ScalaFutures
+}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -178,7 +182,7 @@ class AlpakkaSQSWorkerTest
         TerminalFailure[MySummary](
           failure = new SocketTimeoutException("BOOM"),
           summary = Some("Got a timeout exception, oops")
-        )
+      )
 
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>


### PR DESCRIPTION
For wellcomecollection/platform#5419

This is catch-all logic for any unexpected failures that we don't catch elsewhere, e.g. the SNS sending error we saw last week -- the sort of "once in a blue moon" error we don't see very often, but still want to be able to retry.

It doesn't replace the retrying logic elsewhere in the stack, rather adds SQS retrying on top of it, when everything else has failed.  e.g. if we're doing 1000 S3 operations per SQS message, we want retrying on those operations individually, or we might never succeed.  This is meant to catch errors we can't or haven't handled elsewhere.

Actually terminal failures (e.g. publishing to a non-existent SNS topic) will still be treated as terminal, and see the message deleted from the queue.

---

In an ideal world, I'd consider rewriting the SNS class to implement its own retrying also, but that seems like a bridge too far for this bug – I want to handle it, but I don't want to add lots of complexity to handle such a rare occurrence.