### PR TITLE
Upgrade akka-http so we get JSON-ified HTTP 414 errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+*   Upgrade the version of akka-http and associated libraries
+*   Return JSON errors for an HTTP 414 "URI Too Long", rather than the plaintext errors we were previously returning

--- a/http/src/main/scala/weco/http/errors/WellcomeParsingErrorHandler.scala
+++ b/http/src/main/scala/weco/http/errors/WellcomeParsingErrorHandler.scala
@@ -1,0 +1,40 @@
+package weco.http.errors
+
+import akka.event.LoggingAdapter
+import akka.http.ParsingErrorHandler
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.ServerSettings
+import grizzled.slf4j.Logging
+import weco.http.json.DisplayJsonUtil
+import weco.http.models.DisplayError
+
+/** Akka's URI parser has a maximum length, configured as `parsing.max-uri-length`.
+  *
+  * If it gets a request for a longer URI, it returns a response with Content-Type `text/plain`
+  * and the response body:
+  *
+  *     URI length exceeds the configured limit of 2048 characters
+  *
+  * We occasionally see requests for this sort of URL, which causes errors in our downstream
+  * services, because they always expect JSON responses.  This handler wraps those errors in
+  * our standard JSON error type.
+  *
+  * It may also wrap other kinds of parsing error, but I don't know what other parsing errors
+  * are possible!
+  *
+  * See https://github.com/akka/akka-http/pull/3049
+  * See https://github.com/wellcomecollection/wellcomecollection.org/issues/7586
+  *
+  */
+object WellcomeParsingErrorHandler extends ParsingErrorHandler with DisplayJsonUtil with Logging {
+  override def handle(statusCode: StatusCode, info: ErrorInfo, log: LoggingAdapter, settings: ServerSettings): HttpResponse = {
+    warn(s"Illegal request, responding with status '$statusCode': $info")
+
+    val json = toJson(DisplayError(statusCode = statusCode, description = info.summary))
+
+    HttpResponse(
+      status = statusCode,
+      entity = HttpEntity(ContentTypes.`application/json`, json)
+    )
+  }
+}

--- a/http/src/main/scala/weco/http/errors/WellcomeParsingErrorHandler.scala
+++ b/http/src/main/scala/weco/http/errors/WellcomeParsingErrorHandler.scala
@@ -26,11 +26,18 @@ import weco.http.models.DisplayError
   * See https://github.com/wellcomecollection/wellcomecollection.org/issues/7586
   *
   */
-object WellcomeParsingErrorHandler extends ParsingErrorHandler with DisplayJsonUtil with Logging {
-  override def handle(statusCode: StatusCode, info: ErrorInfo, log: LoggingAdapter, settings: ServerSettings): HttpResponse = {
+object WellcomeParsingErrorHandler
+    extends ParsingErrorHandler
+    with DisplayJsonUtil
+    with Logging {
+  override def handle(statusCode: StatusCode,
+                      info: ErrorInfo,
+                      log: LoggingAdapter,
+                      settings: ServerSettings): HttpResponse = {
     warn(s"Illegal request, responding with status '$statusCode': $info")
 
-    val json = toJson(DisplayError(statusCode = statusCode, description = info.summary))
+    val json = toJson(
+      DisplayError(statusCode = statusCode, description = info.summary))
 
     HttpResponse(
       status = statusCode,

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -79,7 +79,8 @@ class WellcomeHttpAppFeatureTest
         whenGetRequestReady(path) { response =>
           assertIsDisplayError(
             response = response,
-            description = "URI length exceeds the configured limit of 2048 characters",
+            description =
+              "URI length exceeds the configured limit of 2048 characters",
             statusCode = UriTooLong
           )
         }

--- a/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
+++ b/http/src/test/scala/weco/http/WellcomeHttpAppFeatureTest.scala
@@ -3,19 +3,22 @@ package weco.http
 import akka.http.scaladsl.model.StatusCodes.{
   BadRequest,
   InternalServerError,
-  NotFound
+  NotFound,
+  UriTooLong
 }
 import akka.http.scaladsl.model._
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.fixtures.RandomGenerators
 import weco.http.fixtures.HttpFixtures
 
 class WellcomeHttpAppFeatureTest
     extends AnyFunSpec
     with Matchers
     with HttpFixtures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with RandomGenerators {
 
   import weco.http.fixtures.ExampleApp._
 
@@ -65,6 +68,19 @@ class WellcomeHttpAppFeatureTest
           assertIsDisplayError(
             response = response,
             statusCode = InternalServerError
+          )
+        }
+      }
+    }
+
+    it("returns a JSON-typed error if you request an overly long URL") {
+      withApp(exampleApi.routes) { _ =>
+        val path = s"/example?query=${randomAlphanumeric(length = 3000)}"
+        whenGetRequestReady(path) { response =>
+          assertIsDisplayError(
+            response = response,
+            description = "URI length exceeds the configured limit of 2048 characters",
+            statusCode = UriTooLong
           )
         }
       }

--- a/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
+++ b/http/src/test/scala/weco/http/fixtures/HttpFixtures.scala
@@ -108,25 +108,23 @@ trait HttpFixtures
   def assertIsDisplayError(
     response: HttpResponse,
     statusCode: StatusCode
-  ): Assertion = {
+  ): Assertion =
     assertIsDisplayError(
       response = response,
       description = None,
       statusCode = statusCode
     )
-  }
 
   def assertIsDisplayError(
     response: HttpResponse,
     description: String,
     statusCode: StatusCode
-  ): Assertion = {
+  ): Assertion =
     assertIsDisplayError(
       response = response,
       description = Some(description),
       statusCode = statusCode
     )
-  }
 
   def assertIsDisplayError(
     response: HttpResponse,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,6 @@ object Dependencies {
 
     val azure = "12.7.0"
 
-    val akkaHttpCirce = "1.32.0"
     val circe = "0.13.0"
     val typesafe = "1.3.2"
     val jackson = "2.12.3"
@@ -40,7 +39,7 @@ object Dependencies {
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala
     //
     val akka = "2.6.14"
-    val akkaStreamAlpakka = "3.0.1"
+    val akkaStreamAlpakka = "3.0.4"
 
     // Getting the akka-http dependencies right can be fiddly and takes some work.
     // In particular you need to use the same version of akka-http everywhere, or you
@@ -65,7 +64,8 @@ object Dependencies {
     //      one that uses the same version of akka-http and a compatible Circe:
     //      https://github.com/hseeberger/akka-http-json/blob/master/build.sbt
     //
-    val akkaHttp = "10.1.11"
+    val akkaHttp = "10.2.4"
+    val akkaHttpCirce = "1.37.0"
   }
 
   val circeDependencies = Seq(

--- a/sierra/src/main/scala/weco/sierra/http/SierraOauthHttpClient.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraOauthHttpClient.scala
@@ -85,9 +85,7 @@ class SierraOauthHttpClient(
           existingAuthHeaders.isEmpty,
           s"HTTP request already has auth headers: $request")
 
-        request.copy(
-          headers = request.headers :+ Authorization(token)
-        )
+        request.withHeaders(request.headers :+ Authorization(token))
       }
 
       response <- underlying.singleRequest(authenticatedRequest)


### PR DESCRIPTION
Upgrading akka-http is always a bit of a pain, but all the library tests pass so 🤞 this continues to work when it's applied downstream.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/7586