### PR TITLE
Allow access to notes field, make neededBy optional

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Made the `neededBy` field on a hold request optional, and added the ability to (optionally) specify a `note` on holds.

--- a/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
@@ -16,7 +16,7 @@ import weco.sierra.models.fields.{
 }
 import weco.sierra.models.identifiers.{SierraItemNumber, SierraPatronNumber}
 
-import java.time.{LocalDate}
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -140,12 +140,13 @@ class SierraSource(client: HttpClient with HttpGet with HttpPost)(
   def createHold(
     patron: SierraPatronNumber,
     item: SierraItemNumber,
-    neededBy: LocalDate,
+    neededBy: Option[LocalDate] = None,
+    note: Option[String] = None
   ): Future[Either[SierraErrorCode, Unit]] =
     for {
       resp <- client.post(
         path = Path(s"v5/patrons/${patron.withoutCheckDigit}/holds/requests"),
-        body = Some(SierraHoldRequest(item, neededBy))
+        body = Some(SierraHoldRequest(item, neededBy, note))
       )
 
       result <- resp.status match {

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldRequest.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraHoldRequest.scala
@@ -1,5 +1,7 @@
 package weco.sierra.models.fields
 
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
 import weco.sierra.models.identifiers.SierraItemNumber
 
 import java.time.LocalDate
@@ -8,18 +10,32 @@ import java.time.format.DateTimeFormatter
 case class SierraHoldRequest(
   recordType: String,
   recordNumber: Long,
-  neededBy: String,
+  neededBy: Option[String],
+  note: Option[String],
   pickupLocation: String
 )
 
 case object SierraHoldRequest {
-  def apply(item: SierraItemNumber, neededBy: LocalDate): SierraHoldRequest =
-    SierraHoldRequest(
+  def apply(item: SierraItemNumber,
+            neededBy: Option[LocalDate],
+            note: Option[String]): SierraHoldRequest =
+    new SierraHoldRequest(
       recordType = "i",
       recordNumber = item.withoutCheckDigit.toLong,
-      neededBy = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(neededBy),
+      neededBy = neededBy.map(formatDate),
+      note = note,
       // This field is required non-empty by the Sierra API
       // but seems to have no effect
       pickupLocation = "unspecified"
     )
+
+  private lazy val formatDate =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd").format(_)
+
+  // While this can/should be done more globally with a Printer, in this case
+  // that is a huge headache because HttpClient uses CirceUnmarshalling rather than
+  // akkahttpcirce and so doesn't know anything about Printers, and the required
+  // refactor to fix that is large and wide-ranging.
+  implicit val encoder: Encoder[SierraHoldRequest] =
+    deriveEncoder[SierraHoldRequest].mapJson(_.deepDropNullValues)
 }

--- a/sierra/src/test/scala/weco/sierra/http/SierraSourceTest.scala
+++ b/sierra/src/test/scala/weco/sierra/http/SierraSourceTest.scala
@@ -549,7 +549,7 @@ class SierraSourceTest
       )
 
       withSource(responses) { source =>
-        val future = source.createHold(patron, item, neededBy)
+        val future = source.createHold(patron, item, Some(neededBy))
 
         whenReady(future) {
           _.value shouldBe (())
@@ -593,7 +593,7 @@ class SierraSourceTest
       )
 
       withSource(responses) { source =>
-        val future = source.createHold(patron, item, neededBy)
+        val future = source.createHold(patron, item, Some(neededBy))
 
         whenReady(future) {
           _.left.value shouldBe SierraErrorCode(


### PR DESCRIPTION
As I've alluded to in a comment, I started to pull a thread related to Circe encoders and Unmarshallers; we use a mix of https://github.com/hseeberger/akka-http-json and our own `CirceMarshalling` utility, which makes behaviour inconsistent when using some Circe features (namely, `Printer`s). This should probably be addressed at some point, but it looked like quite a long and painful thread so I ducked out in the end...