### PR TITLE
Allow seeding the RNG in RandomGenerators

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Allow seeding an instance of `RandomGenerators` to get deterministic results.

--- a/fixtures/src/test/scala/weco/fixtures/RandomGenerators.scala
+++ b/fixtures/src/test/scala/weco/fixtures/RandomGenerators.scala
@@ -6,8 +6,15 @@ import java.util.UUID
 import scala.util.Random
 
 trait RandomGenerators {
+  // All random generation should use this `random` value, and not
+  // calling `Random` directly.
+  //
+  // This allows downstream callers to get deterministic random data by seeding
+  // the random instance here.
+  protected lazy val random: Random = new Random()
+
   def randomAlphanumeric(length: Int = randomInt(from = 5, to = 10)): String =
-    Random.alphanumeric take length mkString
+    random.alphanumeric take length mkString
 
   def randomAlphanumericWithSpace(length: Int = 8): String = {
     val str = randomAlphanumeric(length).toCharArray
@@ -15,14 +22,14 @@ trait RandomGenerators {
     // Randomly choose an index in the string
     // to replace with a space,
     // avoiding the beginning or the end.
-    val spaceIndex = Random.nextInt(str.length - 2) + 1
+    val spaceIndex = random.nextInt(str.length - 2) + 1
     str.updated(spaceIndex, ' ').toString
   }
 
   def randomBytes(length: Int = 1024): Array[Byte] = {
     val byteArray = new Array[Byte](length)
 
-    Random.nextBytes(byteArray)
+    random.nextBytes(byteArray)
 
     byteArray
   }
@@ -44,7 +51,7 @@ trait RandomGenerators {
 
     assert(difference > 0)
 
-    val randomOffset = Random.nextInt(difference) + 1
+    val randomOffset = random.nextInt(difference) + 1
 
     from + randomOffset
   }
@@ -58,11 +65,11 @@ trait RandomGenerators {
     }
 
   def chooseFrom[T](seq: T*): T =
-    seq(Random.nextInt(seq.size))
+    seq(random.nextInt(seq.size))
 
   def randomSample[T](seq: Seq[T], size: Int): Seq[T] =
-    Random.shuffle(seq).take(size)
+    random.shuffle(seq).take(size)
 
   def randomInstant: Instant =
-    Instant.now().plusSeconds(Random.nextInt())
+    Instant.now().plusSeconds(random.nextInt())
 }

--- a/fixtures/src/test/scala/weco/fixtures/RandomGeneratorsTest.scala
+++ b/fixtures/src/test/scala/weco/fixtures/RandomGeneratorsTest.scala
@@ -18,8 +18,7 @@ class RandomGeneratorsTest extends AnyFunSpec with Matchers {
     val instances = (1 to 5).map(_ =>
       new RandomGenerators {
         override protected lazy val random: Random = new Random(0)
-      }
-    )
+    })
 
     val strings = instances.map(i => i.randomAlphanumeric()).toSet
 

--- a/fixtures/src/test/scala/weco/fixtures/RandomGeneratorsTest.scala
+++ b/fixtures/src/test/scala/weco/fixtures/RandomGeneratorsTest.scala
@@ -1,0 +1,28 @@
+package weco.fixtures
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Random
+
+class RandomGeneratorsTest extends AnyFunSpec with Matchers {
+  it("generates different results each time by default") {
+    val instances = (1 to 5).map(_ => new RandomGenerators {})
+
+    val strings = instances.map(i => i.randomAlphanumeric()).toSet
+
+    strings.size shouldBe 5
+  }
+
+  it("generates different results if you set a random seed") {
+    val instances = (1 to 5).map(_ =>
+      new RandomGenerators {
+        override protected lazy val random: Random = new Random(0)
+      }
+    )
+
+    val strings = instances.map(i => i.randomAlphanumeric()).toSet
+
+    strings.size shouldBe 1
+  }
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

This is relevant for something I [suggested in Slack yesterday](https://wellcome.slack.com/archives/C039RPDLK55/p1650951216006269):

> The ingestor tests should spit out a set of JSON files that represent documents as they’ll exist in Elasticsearch. These could be used for test fixtures in the API repo (whether in Scala or TS) so you can work with real documents without hard-coding a bunch of stuff in the API tests.

We don't want those files to change on every build of the ingestor, and I think allowing callers to seed the random is the best way to get that. You'd have a file like:

```scala
class CreateIngestorJsonFixturesTest extends RandomGenerators
  override protected lazy val random: Random = new Random(0)

  it("creates a work") {
    val w = indexedWork()
    saveWorkToJson("example1.json", w)
  }

  ...
}
```

and then you know `example1.json` will have deterministic output.