### PR TITLE
Enable TCP keepalive for ES clients

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Enable TCP keepalive for the Elasticsearch HTTP client in an effort to stop connection reset errors

--- a/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
+++ b/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
@@ -6,6 +6,7 @@ import org.apache.http.HttpHost
 import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
 import org.apache.http.impl.client.BasicCredentialsProvider
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
+import org.apache.http.impl.nio.reactor.IOReactorConfig
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 
@@ -17,7 +18,16 @@ class ElasticCredentials(username: String, password: String)
 
   override def customizeHttpClient(
     httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder = {
-    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+    httpClientBuilder
+      .setDefaultCredentialsProvider(credentialsProvider)
+      // Enabling TCP keepalive
+      // https://github.com/elastic/elasticsearch/issues/65213
+      .setDefaultIOReactorConfig(
+        IOReactorConfig
+          .custom()
+          .setSoKeepAlive(true)
+          .build()
+      )
   }
 }
 


### PR DESCRIPTION
As per https://github.com/elastic/elasticsearch/issues/65213

Highly speculative attempt at fixing very intermittent errors in the catalogue API