### PR TITLE
Add elasticsearch v7 compatibility headers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add the API compatibility headers for the current version (7) of ElasticSearch

--- a/elasticsearch/docker-compose.yml
+++ b/elasticsearch/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.13.2"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"
@@ -9,3 +9,4 @@ elasticsearch:
     - "cluster.name=wellcome"
     - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     - "discovery.type=single-node"
+    - "xpack.security.enabled=false"

--- a/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
+++ b/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
@@ -2,23 +2,41 @@ package weco.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.http.JavaClient
-import org.apache.http.HttpHost
+import org.apache.http.{HttpHeaders, HttpHost}
 import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
 import org.apache.http.impl.client.BasicCredentialsProvider
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.apache.http.impl.nio.reactor.IOReactorConfig
+import org.apache.http.message.BasicHeader
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 
-class ElasticCredentials(username: String, password: String)
+import scala.collection.JavaConverters._
+
+class ElasticHttpClientConfig(username: String,
+                              password: String,
+                              apiCompatibleWith: Option[String])
     extends HttpClientConfigCallback {
   val credentials = new UsernamePasswordCredentials(username, password)
   val credentialsProvider = new BasicCredentialsProvider()
   credentialsProvider.setCredentials(AuthScope.ANY, credentials)
 
+  // See https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html#_rest_api_compatibility_workflow
+  private val defaultHeaders = apiCompatibleWith
+    .map { compatVersion =>
+      val compatHeader =
+        s"application/vnd.elasticsearch+json;compatible-with=$compatVersion"
+      Seq(
+        new BasicHeader(HttpHeaders.ACCEPT, compatHeader),
+        new BasicHeader(HttpHeaders.CONTENT_TYPE, compatHeader)
+      )
+    }
+    .getOrElse(Nil)
+
   override def customizeHttpClient(
     httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder = {
     httpClientBuilder
+      .setDefaultHeaders(defaultHeaders.asJava)
       .setDefaultCredentialsProvider(credentialsProvider)
       // Enabling TCP keepalive
       // https://github.com/elastic/elasticsearch/issues/65213
@@ -32,6 +50,8 @@ class ElasticCredentials(username: String, password: String)
 }
 
 object ElasticClientBuilder {
+  private val apiCompatibility = Some("7")
+
   def create(hostname: String,
              port: Int,
              protocol: String,
@@ -39,7 +59,8 @@ object ElasticClientBuilder {
              password: String): ElasticClient = {
     val restClient = RestClient
       .builder(new HttpHost(hostname, port, protocol))
-      .setHttpClientConfigCallback(new ElasticCredentials(username, password))
+      .setHttpClientConfigCallback(
+        new ElasticHttpClientConfig(username, password, apiCompatibility))
       .setCompressionEnabled(true)
       .build()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   lazy val versions = new {
     val elasticApm = "1.22.0"
-    val elastic4s = "7.12.2"
+    val elastic4s = "7.15.5"
 
     val aws = "1.11.504"
 
@@ -89,7 +89,8 @@ object Dependencies {
     "org.mockito" % "mockito-core" % versions.mockito % Test
   )
 
-  val testDependencies: Seq[ModuleID] = scalatestDependencies ++ mockitoDependencies
+  val testDependencies
+    : Seq[ModuleID] = scalatestDependencies ++ mockitoDependencies
 
   val sl4jDependencies = Seq(
     "org.clapper" %% "grizzled-slf4j" % versions.grizzled


### PR DESCRIPTION
Upgrade flow [goes like](https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html#_rest_api_compatibility_workflow):
- Add these
- Look at deprecation warnings
- Upgrade cluster
- Look at deprecation warnings
- Upgrade clients

I've upgraded the ES cluster version in the tests here just to make sure it works as a bare minimum.