### PR TITLE
Trying to sort out shapeless/scala version chaos

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Try to sort out the confusing nature of shapeless/scala version resolution

--- a/http/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/http/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -108,7 +108,7 @@ trait BaseCirceSupport {
   private def sourceByteStringMarshaller(
     mediaType: MediaType.WithFixedCharset
   ): Marshaller[SourceOf[ByteString], MessageEntity] =
-    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
+    Marshaller[SourceOf[ByteString], MessageEntity] { _ => value =>
       try FastFuture.successful {
         Marshalling.WithFixedContentType(
           mediaType,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -6,7 +6,7 @@ import sbt._
 
 object Common {
   def createSettings(projectVersion: String): Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.6",
+    scalaVersion := "2.12.15",
     organization := "weco",
     scalacOptions ++= Seq(
       "-deprecation",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
 
     val azure = "12.7.0"
 
+    val circe = "0.14.2"
     val typesafe = "1.3.2"
     val logback = "1.1.8"
     val mockito = "1.10.19"
@@ -37,9 +38,6 @@ object Dependencies {
     val akka = "2.6.19"
     val akkaStreamAlpakka = "3.0.4"
 
-    // As above, this should match the version used by elastic4s
-    val circe = "0.14.2"
-
     // Getting the akka-http dependencies right can be fiddly and takes some work.
     // In particular you need to use the same version of akka-http everywhere, or you
     // get errors (from LargeResponsesTest) like:
@@ -60,13 +58,23 @@ object Dependencies {
     //      (At time of writing, alpakka v3.0.1 pulls in akka-http 10.1.11)
     //
     val akkaHttp = "10.2.9"
+
+    // This needs to be set explicitly to match the language version
+    // used by the version of shapeless that Circe uses, otherwise SBT
+    // is liable to resolve it incorrectly when packaging applications.
+    // Without doing this, you might come across weird errors like:
+    //
+    //    java.lang.NoClassDefFoundError: scala/reflect/internal/Names$Name
+    //
+    val scalaReflectVersion = "2.12.15"
   }
 
   val circeDependencies = Seq(
     "io.circe" %% "circe-core" % versions.circe,
     "io.circe" %% "circe-generic" % versions.circe,
     "io.circe" %% "circe-generic-extras" % versions.circe,
-    "io.circe" %% "circe-parser" % versions.circe
+    "io.circe" %% "circe-parser" % versions.circe,
+    "org.scala-lang" % "scala-reflect" % versions.scalaReflectVersion
   )
 
   val elasticsearchDependencies = Seq(

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -181,35 +181,33 @@ trait DynamoHybridStoreTestCases[
 
       it("if the prefix creates an S3 key that's too long") {
         withStoreContext { implicit context =>
-          withNamespace { implicit namespace =>
-            withTypedStoreImpl { typedStore =>
-              withIndexedStoreImpl { indexedStore =>
-                withHybridStoreImpl(typedStore, indexedStore) { hybridStore =>
-                  // Maximum length of an s3 key is 1024 bytes as of 25/06/2019
-                  // https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+          withTypedStoreImpl { typedStore =>
+            withIndexedStoreImpl { indexedStore =>
+              withHybridStoreImpl(typedStore, indexedStore) { hybridStore =>
+                // Maximum length of an s3 key is 1024 bytes as of 25/06/2019
+                // https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
 
-                  // The hybrid store appends _some_ value to this path.
-                  // This test sets the id length to 1024 expecting the
-                  // implementation to append >0 bytes thereby causing
-                  // a failure.
+                // The hybrid store appends _some_ value to this path.
+                // This test sets the id length to 1024 expecting the
+                // implementation to append >0 bytes thereby causing
+                // a failure.
 
-                  // There is also a dynamo hash/range key restriction but
-                  // this is (at time of writing) greater than the s3 key
-                  // length restriction and cannot be reached without
-                  // invoking this error.
+                // There is also a dynamo hash/range key restriction but
+                // this is (at time of writing) greater than the s3 key
+                // length restriction and cannot be reached without
+                // invoking this error.
 
-                  val tooLongId = randomStringOfByteLength(1024)
+                val tooLongId = randomStringOfByteLength(1024)
 
-                  val id = Version(id = tooLongId, version = 1)
-                  val hybridStoreEntry = createT
+                val id = Version(id = tooLongId, version = 1)
+                val hybridStoreEntry = createT
 
-                  val result = hybridStore.put(id)(hybridStoreEntry)
-                  val value = result.left.value
+                val result = hybridStore.put(id)(hybridStoreEntry)
+                val value = result.left.value
 
-                  value shouldBe a[InvalidIdentifierFailure]
-                  value.e.getMessage should startWith(
-                    "S3 object key byte length is too big")
-                }
+                value shouldBe a[InvalidIdentifierFailure]
+                value.e.getMessage should startWith(
+                  "S3 object key byte length is too big")
               }
             }
           }


### PR DESCRIPTION
I have confirmed that setting this `scala-reflect` version on an application itself fixes the problem we've been seeing - I hope that setting it here (rather than having to use it in every application) will work too!