### PR TITLE
Retry looking up the destination blob when replicating to Azure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix an issue where the `AzureTransfer` class might try to overwrite a blob in Azure if it got a transient error while trying to retrieve the blob in the destination.  Also log when objects/blobs are overwritten because the destination object can't be retrieved and it's not a 404 Not Found.

--- a/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -3,20 +3,17 @@ package weco.storage.transfer.azure
 import java.io.{ByteArrayInputStream, InputStream}
 import java.net.URL
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{S3ObjectInputStream, S3ObjectSummary}
+import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.azure.storage.blob.BlobServiceClient
 import com.azure.storage.blob.models.{
   BlobRange,
   BlobStorageException,
   BlockListType
 }
-import com.azure.storage.blob.specialized.{BlobInputStream, BlockBlobClient}
+import com.azure.storage.blob.specialized.BlockBlobClient
 import grizzled.slf4j.Logging
 import org.apache.commons.io.IOUtils
-import weco.storage.azure.AzureBlobLocation
 import weco.storage.models.ByteRange
-import weco.storage.s3.S3ObjectLocation
-import weco.storage.services.azure.AzureSizeFinder
 import weco.storage.services.s3.{S3RangedReader, S3Uploader}
 import weco.storage.transfer._
 import weco.storage.{Identified, NotFoundError, RetryableError, StoreWriteError}

--- a/storage/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
@@ -19,7 +19,8 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 class S3Transfer(transferManager: TransferManager, s3Readable: S3StreamReadable)
-    extends Transfer[S3ObjectLocation, S3ObjectLocation] with Logging {
+    extends Transfer[S3ObjectLocation, S3ObjectLocation]
+    with Logging {
 
   import weco.storage.RetryOps._
 


### PR DESCRIPTION
Yesterday we got a 409 error from the bag replicator:

> BlobImmutableDueToLegalHold: This operation is not permitted as the blob is immutable due to one or more legal holds.

This should be impossible -- the Azure replicator is meant to check for an existing object in the destination, and skip overwriting it if present. (If the object matches what it was about to write, it's a no-op.  If it's different, it gets flagged as an error.)

Upon reading the code, we spotted a bug in the Azure logic: if there was *any* error retrieving the existing blob, it would proceed to overwrite the existing object.  This includes transient errors, e.g. a timeout.

This makes two changes to this logic:

*   It uses the AzureStreamStore and S3StreamStore, which both have code to retry flaky errors.  We already use this in S3Transfer; it should prevent transient errors breaking the Azure replication.
*   If there's any error looking up the destination stream which isn't a 404 Not Found, it logs a warning, so we can debug it next time.

This is something we discovered during a shared debugging session; notes below.

For https://github.com/wellcomecollection/storage-service/issues/1025

## Debugging session notes

The storage service is responsible for the safe storage of our digital collections (including both digitised and born-digital material). This includes verifying the checksums, copying the files to three separate locations, and so on. The [storage service repo](https://github.com/wellcomecollection/storage-service) and [introductory blog post](https://stacks.wellcomecollection.org/building-wellcome-collections-new-archival-storage-service-3f68ff21927e) have more information.

It's built as a data pipeline, similar to the catalogue/concepts pipeline. Each step in the pipeline sends updates to the ingests database ("started step X", "finished step Y"), which in turn get shoved into the reporting cluster.

Once a day, a Lambda fetches the last 48 hours worth of ingests from the reporting cluster, and posts a summary message to Slack.

<img width="411" alt="Screenshot 2022-10-10 at 12 47 36" src="https://user-images.githubusercontent.com/301220/194859400-ed8d742d-bc8b-4615-9ed9-37ec49ff7dbf.png">

Normally it just gives us stats on how much is being stored:

<img width="344" alt="Screenshot 2022-10-10 at 12 49 59" src="https://user-images.githubusercontent.com/301220/194859804-684caff5-daf6-4149-a846-1cb6bff22d46.png">

It groups ingests into four buckets:

* succeeded (stored successfully, nothing to do)
* failed, user error (something went wrong, but not for devs – e.g. somebody uploaded a file with the wrong checksum)
* stalled (nothing has happened in 24 hours, might need investigation)
* failed, unknown error (something went wrong and needs dev investigation)

The latter is what happened over the weekend:

<img width="323" alt="Screenshot 2022-10-10 at 12 51 08" src="https://user-images.githubusercontent.com/301220/194860017-99521e2b-06ea-4d9b-96d2-1956b185e549.png">

Clicking the red ingest ID takes you to the [ingest inspector](https://wellcome-ingest-inspector.glitch.me/ingests/b9789775-6db3-4ebc-94aa-a84be2b5cb72), which gives a human-readable view of the ingest. It highlights the failing event, and includes a link to the dev logs:

<img width="607" alt="Screenshot 2022-10-10 at 12 52 13" src="https://user-images.githubusercontent.com/301220/194860203-8a14edc6-6b1f-4c5e-a2e0-0e2d13421ecb.png">

Clicking that takes you to the logging cluster, with a pre-filled query for the app in question and the approximate timeframe of the error. Looking through the logs is how we found the error, and then reading the replicator code we found this bug.