### PR TITLE
Remove what seems to be an unused setting

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -52,7 +52,6 @@ object Common {
     project
       .in(new File(folder))
       .settings(settings: _*)
-      .settings(DockerCompose.settings: _*)
       .enablePlugins(DockerComposePlugin)
       .dependsOn(dependsOn: _*)
       .settings(libraryDependencies ++= externalDependencies)

--- a/project/DockerCompose.scala
+++ b/project/DockerCompose.scala
@@ -1,8 +1,0 @@
-import sbt._
-import com.tapad.docker.DockerComposePlugin.autoImport._
-
-object DockerCompose {
-  val settings: Seq[Def.Setting[_]] = Seq(
-    composeNoBuild := true
-  )
-}


### PR DESCRIPTION
I'm getting a warning from sbt:

```
[warn] there are 15 keys that are not used by any other settings/tasks:
[warn]
[warn] * elasticsearch / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * elasticsearch_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * fixtures / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * http / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * http_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * json / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * messaging / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * messaging_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * monitoring / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * monitoring_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * sierra / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * sierra_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * storage / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * storage_typesafe / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn] * typesafe_app / composeNoBuild
[warn]   +- /Users/alexwlchan/repos/scala-libs/project/DockerCompose.scala:6
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```

We don't seem to use this setting in any of our other projects, so let's try removing it.