### PR TITLE
Preparing the way for the AWS Java V2 SDK for S3, part 1 (remove batchSize; small clean-ups)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+Remove batchSize from S3ObjectLocationListing.
+
+This is never set to a non-default value, so there should be no impact on downstream code.
+
+Also contains some refactoring ahead of upgrading to the AWS Java V2 SDK for S3.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,10 @@ object Dependencies {
     val elasticApm = "1.22.0"
     val elastic4s = "8.3.2"
 
-    val aws = "1.11.504"
+    val aws1 = "1.11.504"
 
     // Moving what we can to version 2 of the AWS SDKs
-    val aws2 = "2.19.0"
+    val aws = "2.19.0"
 
     val azure = "12.7.0"
 
@@ -138,18 +138,18 @@ object Dependencies {
   )
 
   val localstackDependencies = Seq(
-    "software.amazon.awssdk" % "auth" % versions.aws2,
-    "software.amazon.awssdk" % "regions" % versions.aws2
+    "software.amazon.awssdk" % "auth" % versions.aws,
+    "software.amazon.awssdk" % "regions" % versions.aws
   )
 
   val monitoringDependencies = Seq(
-    "software.amazon.awssdk" % "cloudwatch" % versions.aws2
+    "software.amazon.awssdk" % "cloudwatch" % versions.aws
   ) ++
     testDependencies
 
   val messagingDependencies = Seq(
-    "software.amazon.awssdk" % "sns" % versions.aws2,
-    "software.amazon.awssdk" % "sqs" % versions.aws2,
+    "software.amazon.awssdk" % "sns" % versions.aws,
+    "software.amazon.awssdk" % "sqs" % versions.aws,
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakka
     // This needs to be excluded because it conflicts with aws http client "netty-nio-client"
     // and it also causes weird leaks between tests
@@ -176,8 +176,8 @@ object Dependencies {
 
   val storageDependencies: Seq[ModuleID] = Seq(
     "com.azure" % "azure-storage-blob" % versions.azure,
-    "software.amazon.awssdk" % "dynamodb" % versions.aws2,
-    "com.amazonaws" % "aws-java-sdk-s3" % versions.aws
+    "software.amazon.awssdk" % "dynamodb" % versions.aws,
+    "com.amazonaws" % "aws-java-sdk-s3" % versions.aws1
   ) ++
     scanamoDependencies ++
     apacheCommons

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val aws = "1.11.504"
 
     // Moving what we can to version 2 of the AWS SDKs
-    val aws2 = "2.11.14"
+    val aws2 = "2.19.0"
 
     val azure = "12.7.0"
 

--- a/storage/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
+++ b/storage/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
@@ -16,10 +16,9 @@ class S3ObjectLocationListing(implicit summaryListing: S3ObjectSummaryListing)
 }
 
 object S3ObjectLocationListing {
-  def apply(batchSize: Int = 1000)(
-    implicit s3Client: AmazonS3): S3ObjectLocationListing = {
+  def apply()(implicit s3Client: AmazonS3): S3ObjectLocationListing = {
     implicit val summaryListing: S3ObjectSummaryListing =
-      new S3ObjectSummaryListing(batchSize)
+      new S3ObjectSummaryListing()
 
     new S3ObjectLocationListing()
   }

--- a/storage/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
+++ b/storage/src/main/scala/weco/storage/listing/s3/S3ObjectLocationListing.scala
@@ -2,7 +2,6 @@ package weco.storage.listing.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
-import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 class S3ObjectLocationListing(implicit summaryListing: S3ObjectSummaryListing)
     extends S3Listing[S3ObjectLocation] {

--- a/storage/src/main/scala/weco/storage/listing/s3/S3ObjectSummaryListing.scala
+++ b/storage/src/main/scala/weco/storage/listing/s3/S3ObjectSummaryListing.scala
@@ -10,9 +10,7 @@ import weco.storage.s3.S3ObjectLocationPrefix
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-class S3ObjectSummaryListing(batchSize: Int = 1000)(
-  implicit s3Client: AmazonS3
-) extends S3Listing[S3ObjectSummary]
+class S3ObjectSummaryListing()(implicit s3Client: AmazonS3) extends S3Listing[S3ObjectSummary]
     with Logging {
   override def list(prefix: S3ObjectLocationPrefix): ListingResult = {
     if (!prefix.keyPrefix.endsWith("/") && prefix.keyPrefix != "") {
@@ -30,7 +28,6 @@ class S3ObjectSummaryListing(batchSize: Int = 1000)(
           prefix.bucket,
           prefix.keyPrefix
         )
-        .withBatchSize(batchSize)
         .asScala
 
       // Because the iterator is lazy, it won't make the initial call to S3 until

--- a/storage/src/main/scala/weco/storage/listing/s3/S3ObjectSummaryListing.scala
+++ b/storage/src/main/scala/weco/storage/listing/s3/S3ObjectSummaryListing.scala
@@ -10,7 +10,8 @@ import weco.storage.s3.S3ObjectLocationPrefix
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-class S3ObjectSummaryListing()(implicit s3Client: AmazonS3) extends S3Listing[S3ObjectSummary]
+class S3ObjectSummaryListing()(implicit s3Client: AmazonS3)
+    extends S3Listing[S3ObjectSummary]
     with Logging {
   override def list(prefix: S3ObjectLocationPrefix): ListingResult = {
     if (!prefix.keyPrefix.endsWith("/") && prefix.keyPrefix != "") {

--- a/storage/src/main/scala/weco/storage/services/s3/S3SizeFinder.scala
+++ b/storage/src/main/scala/weco/storage/services/s3/S3SizeFinder.scala
@@ -29,9 +29,9 @@ class S3SizeFinder(val maxRetries: Int = 3)(implicit s3Client: AmazonS3)
     } match {
       case Success(length) => length
       case Failure(_) =>
-        val s3Object = s3Client.getObject(
-          new GetObjectRequest(location.bucket, location.key)
-        )
+        val getRequest = new GetObjectRequest(location.bucket, location.key)
+
+        val s3Object = s3Client.getObject(getRequest)
         val metadata = s3Object.getObjectMetadata
         val contentLength = metadata.getContentLength
 

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamReadable.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamReadable.scala
@@ -1,6 +1,7 @@
 package weco.storage.store.s3
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.GetObjectRequest
 import weco.storage._
 import weco.storage.s3.{S3Errors, S3ObjectLocation}
 import weco.storage.store.RetryableReadable
@@ -12,7 +13,9 @@ trait S3StreamReadable
 
   override protected def retryableGetFunction(
     location: S3ObjectLocation): InputStreamWithLength = {
-    val retrievedObject = s3Client.getObject(location.bucket, location.key)
+    val getRequest = new GetObjectRequest(location.bucket, location.key)
+
+    val retrievedObject = s3Client.getObject(getRequest)
 
     new InputStreamWithLength(
       retrievedObject.getObjectContent,

--- a/storage/src/main/scala/weco/storage/store/s3/S3TypedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3TypedStore.scala
@@ -1,9 +1,7 @@
 package weco.storage.store.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.TypedStore
-import weco.storage.streaming.Codec
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.streaming.Codec
 

--- a/storage/src/test/scala/weco/storage/listing/s3/S3ListingFixtures.scala
+++ b/storage/src/test/scala/weco/storage/listing/s3/S3ListingFixtures.scala
@@ -33,6 +33,5 @@ trait S3ListingFixtures[ListingResult]
       testWith(bucket)
     }
 
-  def createS3Listing(batchSize: Int = 1000)(
-    implicit s3Client: AmazonS3 = s3Client): S3Listing[ListingResult]
+  def createS3Listing(implicit s3Client: AmazonS3 = s3Client): S3Listing[ListingResult]
 }

--- a/storage/src/test/scala/weco/storage/listing/s3/S3ListingTestCases.scala
+++ b/storage/src/test/scala/weco/storage/listing/s3/S3ListingTestCases.scala
@@ -6,7 +6,6 @@ import weco.fixtures.TestWith
 import weco.storage.fixtures.S3Fixtures.Bucket
 import weco.storage.listing.ListingTestCases
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
-import weco.storage.fixtures.S3Fixtures.Bucket
 
 trait S3ListingTestCases[ListingResult]
     extends ListingTestCases[

--- a/storage/src/test/scala/weco/storage/listing/s3/S3ObjectLocationListingTest.scala
+++ b/storage/src/test/scala/weco/storage/listing/s3/S3ObjectLocationListingTest.scala
@@ -9,7 +9,6 @@ class S3ObjectLocationListingTest extends S3ListingTestCases[S3ObjectLocation] {
                                    entries: Seq[S3ObjectLocation]): Assertion =
     result.toSeq should contain theSameElementsAs entries
 
-  override def createS3Listing(batchSize: Int = 1000)(
-    implicit s3Client: AmazonS3 = s3Client): S3Listing[S3ObjectLocation] =
-    S3ObjectLocationListing(batchSize)
+  override def createS3Listing(implicit s3Client: AmazonS3 = s3Client): S3Listing[S3ObjectLocation] =
+    S3ObjectLocationListing()
 }

--- a/storage/src/test/scala/weco/storage/listing/s3/S3ObjectSummaryListingTest.scala
+++ b/storage/src/test/scala/weco/storage/listing/s3/S3ObjectSummaryListingTest.scala
@@ -17,7 +17,6 @@ class S3ObjectSummaryListingTest extends S3ListingTestCases[S3ObjectSummary] {
     actualLocations should contain theSameElementsAs entries
   }
 
-  override def createS3Listing(batchSize: Int = 1000)(
-    implicit s3Client: AmazonS3 = s3Client): S3Listing[S3ObjectSummary] =
-    new S3ObjectSummaryListing(batchSize)
+  override def createS3Listing(implicit s3Client: AmazonS3 = s3Client): S3Listing[S3ObjectSummary] =
+    new S3ObjectSummaryListing()
 }

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamReadableTest.scala
@@ -1,7 +1,7 @@
 package weco.storage.store.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.AmazonS3Exception
+import com.amazonaws.services.s3.model.{AmazonS3Exception, GetObjectRequest}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.EitherValues
@@ -39,7 +39,8 @@ class S3StreamReadableTest
 
       readable.get(location).left.value shouldBe a[DoesNotExistError]
 
-      verify(spyClient, times(1)).getObject(location.bucket, location.key)
+      verify(spyClient, times(1))
+        .getObject(new GetObjectRequest(location.bucket, location.key))
     }
   }
 
@@ -50,14 +51,14 @@ class S3StreamReadableTest
       val location = createS3ObjectLocationWith(bucket)
       putStream(location)
 
-      when(mockClient.getObject(any[String], any[String]))
+      when(mockClient.getObject(any[GetObjectRequest]))
         .thenThrow(s3ServerException)
-        .thenReturn(s3Client.getObject(location.bucket, location.key))
+        .thenReturn(s3Client.getObject(new GetObjectRequest(location.bucket, location.key)))
 
       val readable = createS3ReadableWith(mockClient, retries = 3)
       readable.get(location) shouldBe a[Right[_, _]]
 
-      verify(mockClient, times(2)).getObject(location.bucket, location.key)
+      verify(mockClient, times(2)).getObject(new GetObjectRequest(location.bucket, location.key))
     }
   }
 
@@ -68,7 +69,7 @@ class S3StreamReadableTest
 
     val retries = 4
 
-    when(mockClient.getObject(any[String], any[String]))
+    when(mockClient.getObject(any[GetObjectRequest]))
       .thenThrow(s3ServerException)
       .thenThrow(s3ServerException)
       .thenThrow(s3ServerException)
@@ -77,7 +78,7 @@ class S3StreamReadableTest
     val readable = createS3ReadableWith(mockClient, retries = retries)
     readable.get(location).left.value shouldBe a[StoreReadError]
 
-    verify(mockClient, times(retries)).getObject(location.bucket, location.key)
+    verify(mockClient, times(retries)).getObject(new GetObjectRequest(location.bucket, location.key))
   }
 
   it("retries if it's unable to connect to S3") {
@@ -93,7 +94,7 @@ class S3StreamReadableTest
 
       readable.get(location).left.value shouldBe a[StoreReadError]
 
-      verify(spyClient, times(retries)).getObject(location.bucket, location.key)
+      verify(spyClient, times(retries)).getObject(new GetObjectRequest(location.bucket, location.key))
     }
   }
 
@@ -110,7 +111,7 @@ class S3StreamReadableTest
 
       readable.get(location).left.value shouldBe a[StoreReadError]
 
-      verify(spyClient, times(retries)).getObject(location.bucket, location.key)
+      verify(spyClient, times(retries)).getObject(new GetObjectRequest(location.bucket, location.key))
     }
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4785

Trying to migrate all of scala-libs in one go is too big to be manageable, so I'm going to break it down into smaller PRs. This has the first bit of refactoring for the V2 SDK:

* Remove some duplicate imports
* Construct requests as standalone variables. The V2 SDK changes how requests are constructed quite dramatically, e.g.

    ```scala
    new GetObjectRequest("my-bukkit", "cat.jpg")
    ```
 
    becomes

    ```scala
    GetObjectRequest.builder()
      .bucket("my-bukkit")
      .key("cat.jpg")
      .build()
    ```

    The latter has more clarity, but you really want to construct it as a separate variable before calling the SDK method.

    Pulling out those requests as separate variables now reduces the diff churn before the V2 upgrade. Compare:

    ```diff
    -s3Client.getObject(new GetObjectRequest("my-bukkit", "cat.jpg"))
    +val request = GetObjectRequest.builder()
    +  .bucket("my-bukkit")
    +  .key("cat.jpg")
    +  .build()
    +s3Client.getObject(request)
    ```

    and
    ```diff
    -val request = new GetObjectRequest("my-bukkit", "cat.jpg")
    +val request = GetObjectRequest.builder()
    +  .bucket("my-bukkit")
    +  .key("cat.jpg")
    +  .build()
     s3Client.getObject(request)
    ```

* Remove the `batchSize` parameter from S3ObjectLocationListing. It's not obvious if/how this can be achieved in the V2 SDK, and we never set it to a non-default value in production code, just in tests.  Let's get rid of it to simplify things.
