### PR TITLE
Preparing the way for the AWS Java V2 SDK for S3, part 3 (Remove the checkForExisting flag from the Transfer classes)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Remove the `checkForExisting` flag from Transfer and TransferPrefix.
+
+These classes will now *always* check for an existing object before overwriting it.

--- a/storage/src/main/scala/weco/storage/transfer/PrefixTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/PrefixTransfer.scala
@@ -20,7 +20,6 @@ trait PrefixTransfer[SrcPrefix, SrcLocation, DstPrefix, DstLocation]
     iterator: Iterable[SrcLocation],
     srcPrefix: SrcPrefix,
     dstPrefix: DstPrefix,
-    checkForExisting: Boolean
   ): Either[PrefixTransferIncomplete, PrefixTransferSuccess] = {
     var successes = 0
     var failures = 0
@@ -38,8 +37,7 @@ trait PrefixTransfer[SrcPrefix, SrcLocation, DstPrefix, DstLocation]
                   srcPrefix = srcPrefix,
                   dstPrefix = dstPrefix,
                   srcLocation = srcLocation
-                ),
-                checkForExisting = checkForExisting
+                )
               )
             )
           }
@@ -63,8 +61,7 @@ trait PrefixTransfer[SrcPrefix, SrcLocation, DstPrefix, DstLocation]
 
   def transferPrefix(
     srcPrefix: SrcPrefix,
-    dstPrefix: DstPrefix,
-    checkForExisting: Boolean = true
+    dstPrefix: DstPrefix
   ): Either[PrefixTransferFailure, PrefixTransferSuccess] = {
     listing.list(srcPrefix) match {
       case Left(error) =>
@@ -74,8 +71,7 @@ trait PrefixTransfer[SrcPrefix, SrcLocation, DstPrefix, DstLocation]
         copyPrefix(
           iterator = iterable,
           srcPrefix = srcPrefix,
-          dstPrefix = dstPrefix,
-          checkForExisting = checkForExisting
+          dstPrefix = dstPrefix
         )
     }
   }

--- a/storage/src/main/scala/weco/storage/transfer/Transfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/Transfer.scala
@@ -6,17 +6,16 @@ trait Transfer[SrcLocation, DstLocation] {
 
   type TransferEither = Either[FailureResult, SuccessResult]
 
-  def transfer(src: SrcLocation,
-               dst: DstLocation,
-               checkForExisting: Boolean = true): TransferEither =
-    if (checkForExisting) {
-      transferWithCheckForExisting(src, dst)
-    } else {
-      transferWithOverwrites(src, dst)
-    }
-
-  protected def transferWithCheckForExisting(src: SrcLocation,
-                                             dst: DstLocation): TransferEither
-  protected def transferWithOverwrites(src: SrcLocation,
-                                       dst: DstLocation): TransferEither
+  // Note: implementations are expected to check whether there is already
+  // an object at `dst`, and if so:
+  //
+  //    - Return a TransferNoOp if it matches the source object
+  //    - Return a TransferOverwriteFailure if it is different to the source object
+  //
+  // We used to skip checking for an existing object if we knew there was nothing
+  // there (and to avoid consistency issues with S3), but in August 2022 we switched
+  // to always checking for a destination object first.
+  //
+  // See https://github.com/wellcomecollection/platform/issues/3897#issuecomment-1201264674
+  def transfer(src: SrcLocation, dst: DstLocation): TransferEither
 }

--- a/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -191,16 +191,21 @@ trait AzureTransfer[Context]
       case Failure(err) => throw err
     }
 
-  override def transfer(src: SourceS3Object, dst: AzureBlobLocation): TransferEither =
+  override def transfer(src: SourceS3Object,
+                        dst: AzureBlobLocation): TransferEither =
     getAzureStream(dst) match {
       // If the destination object doesn't exist, we can go ahead and
       // start the transfer.
       case Left(_: NotFoundError) =>
-        runTransfer(src, dst).map { _ => TransferPerformed(src, dst) }
+        runTransfer(src, dst).map { _ =>
+          TransferPerformed(src, dst)
+        }
 
       case Left(e) =>
         warn(s"Unexpected error retrieving Azure blob from $dst: $e")
-        runTransfer(src, dst).map { _ => TransferPerformed(src, dst) }
+        runTransfer(src, dst).map { _ =>
+          TransferPerformed(src, dst)
+        }
 
       case Right(Identified(_, dstStream)) =>
         val srcObjectLocation = src.location
@@ -381,7 +386,8 @@ class AzurePutBlockFromUrlTransfer(s3Uploader: S3Uploader,
   private def isWeirdKey(key: String): Boolean =
     key.endsWith(".")
 
-  override def transfer(src: SourceS3Object, dst: AzureBlobLocation): TransferEither =
+  override def transfer(src: SourceS3Object,
+                        dst: AzureBlobLocation): TransferEither =
     if (isWeirdKey(src.location.key)) {
       blockTransfer.transfer(src, dst)
     } else {

--- a/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/azure/AzureTransfer.scala
@@ -83,7 +83,6 @@ trait AzureTransfer[Context]
     src: S3ObjectLocation,
     dst: AzureBlobLocation,
     s3Length: Long,
-    allowOverwrites: Boolean,
     context: Context
   ): Try[Unit] = {
     val blockClient = blobServiceClient

--- a/storage/src/main/scala/weco/storage/transfer/memory/MemoryTransfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/memory/MemoryTransfer.scala
@@ -6,8 +6,7 @@ import weco.storage.transfer._
 trait MemoryTransfer[Ident, T]
     extends Transfer[Ident, Ident]
     with MemoryStoreBase[Ident, T] {
-  override def transferWithCheckForExisting(src: Ident,
-                                            dst: Ident): TransferEither =
+  override def transfer(src: Ident, dst: Ident): TransferEither =
     (entries.get(src), entries.get(dst)) match {
       case (Some(srcT), Some(dstT)) if srcT == dstT =>
         Right(TransferNoOp(src, dst))
@@ -17,16 +16,6 @@ trait MemoryTransfer[Ident, T]
         entries = entries ++ Map(dst -> srcT)
         Right(TransferPerformed(src, dst))
       case (None, _) =>
-        Left(TransferSourceFailure(src, dst))
-    }
-
-  override def transferWithOverwrites(src: Ident, dst: Ident): TransferEither =
-    entries.get(src) match {
-      case Some(srcT) =>
-        entries = entries ++ Map(dst -> srcT)
-        Right(TransferPerformed(src, dst))
-
-      case None =>
         Left(TransferSourceFailure(src, dst))
     }
 }

--- a/storage/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
+++ b/storage/src/main/scala/weco/storage/transfer/s3/S3Transfer.scala
@@ -24,7 +24,8 @@ class S3Transfer(transferManager: TransferManager, s3Readable: S3StreamReadable)
 
   import weco.storage.RetryOps._
 
-  override def transfer(src: S3ObjectLocation, dst: S3ObjectLocation): TransferEither =
+  override def transfer(src: S3ObjectLocation,
+                        dst: S3ObjectLocation): TransferEither =
     getStream(dst) match {
 
       // If the destination object doesn't exist, we can go ahead and

--- a/storage/src/test/scala/weco/storage/transfer/PrefixTransferTestCases.scala
+++ b/storage/src/test/scala/weco/storage/transfer/PrefixTransferTestCases.scala
@@ -318,38 +318,5 @@ trait PrefixTransferTestCases[SrcLocation,
           }
       }
     }
-
-    it("overwrites an existing object if checkForExisting=false") {
-      withNamespacePair {
-        case (srcNamespace, dstNamespace) =>
-          val srcPrefix = createSrcPrefix(srcNamespace)
-          val dstPrefix = createDstPrefix(dstNamespace)
-
-          val src = createSrcLocationFrom(srcPrefix, suffix = "1.txt")
-          val dst = createDstLocationFrom(dstPrefix, suffix = "1.txt")
-
-          val srcT = createT
-          val dstT = createT
-
-          withContext { implicit context =>
-            withSrcStore(initialEntries = Map(src -> srcT)) { srcStore =>
-              withDstStore(initialEntries = Map(dst -> dstT)) { dstStore =>
-                val result =
-                  withPrefixTransfer(srcStore, dstStore) {
-                    _.transferPrefix(
-                      srcPrefix = srcPrefix,
-                      dstPrefix = dstPrefix,
-                      checkForExisting = false)
-                  }
-
-                result.value shouldBe PrefixTransferSuccess(1)
-
-                srcStore.get(src).value.identifiedT shouldBe srcT
-                dstStore.get(dst).value.identifiedT shouldBe srcT
-              }
-            }
-          }
-      }
-    }
   }
 }

--- a/storage/src/test/scala/weco/storage/transfer/TransferTestCases.scala
+++ b/storage/src/test/scala/weco/storage/transfer/TransferTestCases.scala
@@ -153,55 +153,5 @@ trait TransferTestCases[SrcLocation,
           }
       }
     }
-
-    it("fails if the source is absent and checkForExisting=false") {
-      withNamespacePair {
-        case (srcNamespace, dstNamespace) =>
-          val src = createSrcLocation(srcNamespace)
-          val dst = createDstLocation(dstNamespace)
-
-          withContext { implicit context =>
-            withSrcStore(initialEntries = Map.empty) { srcStore =>
-              withDstStore(initialEntries = Map.empty) { dstStore =>
-                val result =
-                  withTransfer(srcStore, dstStore) {
-                    _.transfer(src, dst, checkForExisting = false)
-                  }
-
-                result.left.value shouldBe a[TransferSourceFailure[_, _]]
-
-                result.left.value.src shouldBe src
-                result.left.value.dst shouldBe dst
-              }
-            }
-          }
-      }
-    }
-
-    it("overwrites the destination if checkForExisting=false") {
-      withNamespacePair {
-        case (srcNamespace, dstNamespace) =>
-          val (src, srcT) = createSrcObject(srcNamespace)
-
-          val dst = createDstLocation(dstNamespace)
-          val dstT = createT
-
-          withContext { implicit context =>
-            withSrcStore(initialEntries = Map(src -> srcT)) { srcStore =>
-              withDstStore(initialEntries = Map(dst -> dstT)) { dstStore =>
-                val result =
-                  withTransfer(srcStore, dstStore) {
-                    _.transfer(src, dst, checkForExisting = false)
-                  }
-
-                result.value shouldBe TransferPerformed(src, dst)
-
-                srcStore.get(src).value.identifiedT shouldBe srcT
-                dstStore.get(dst).value.identifiedT shouldBe srcT
-              }
-            }
-          }
-      }
-    }
   }
 }

--- a/storage/src/test/scala/weco/storage/transfer/azure/AzurePutBlockFromURLTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/azure/AzurePutBlockFromURLTransferTest.scala
@@ -43,9 +43,7 @@ class AzurePutBlockFromURLTransferTest
 
           dstStore.put(dst)("Hello world") shouldBe a[Right[_, _]]
 
-          transfer
-            .transfer(srcObject, dst, checkForExisting = true)
-            .value shouldBe TransferNoOp(srcObject, dst)
+          transfer.transfer(srcObject, dst).value shouldBe TransferNoOp(srcObject, dst)
         }
       }
     }
@@ -63,9 +61,7 @@ class AzurePutBlockFromURLTransferTest
           )
           dstStore.put(dst)("HELLO WORLD") shouldBe a[Right[_, _]]
 
-          transfer
-            .transfer(srcObject, dst, checkForExisting = true)
-            .value shouldBe TransferNoOp(srcObject, dst)
+          transfer.transfer(srcObject, dst).value shouldBe TransferNoOp(srcObject, dst)
         }
       }
     }
@@ -83,10 +79,7 @@ class AzurePutBlockFromURLTransferTest
           )
           dstStore.put(dst)("Greetings, humans") shouldBe a[Right[_, _]]
 
-          transfer
-            .transfer(srcObject, dst, checkForExisting = true)
-            .left
-            .value shouldBe a[TransferOverwriteFailure[_, _]]
+          transfer.transfer(srcObject, dst).left.value shouldBe a[TransferOverwriteFailure[_, _]]
         }
       }
     }
@@ -110,11 +103,7 @@ class AzurePutBlockFromURLTransferTest
             size = "Hello world".getBytes().length
           )
 
-          transfer.transfer(
-            src = srcObject,
-            dst = dst,
-            checkForExisting = true
-          ) shouldBe a[Right[_, _]]
+          transfer.transfer(src = srcObject, dst = dst) shouldBe a[Right[_, _]]
 
           dstStore.get(dst).value.identifiedT shouldBe "Hello world"
         }
@@ -141,11 +130,7 @@ class AzurePutBlockFromURLTransferTest
           size = "Hello world".getBytes().length
         )
 
-        transfer.transfer(
-          src = srcObject,
-          dst = dst,
-          checkForExisting = true
-        )
+        transfer.transfer(src = srcObject, dst = dst)
 
         verify(s3Uploader).getPresignedGetURL(src, urlValidity)
       }

--- a/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/memory/MemoryPrefixTransferTest.scala
@@ -163,9 +163,7 @@ class MemoryPrefixTransferTest
   ): R = {
     val prefixTransfer = new MemoryMemoryLocationPrefixTransfer(
       initialEntries = srcStore.entries ++ dstStore.entries) {
-      override def transfer(src: MemoryLocation,
-                            dst: MemoryLocation,
-                            checkForExisting: Boolean = true): TransferEither =
+      override def transfer(src: MemoryLocation, dst: MemoryLocation): TransferEither =
         Left(TransferSourceFailure(src, dst))
     }
 

--- a/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
+++ b/storage/src/test/scala/weco/storage/transfer/s3/S3PrefixTransferTest.scala
@@ -99,7 +99,7 @@ class S3PrefixTransferTest
     implicit val transfer: S3Transfer = mock[S3Transfer]
     when(
       transfer
-        .transfer(any[S3ObjectLocation], any[S3ObjectLocation], any[Boolean]))
+        .transfer(any[S3ObjectLocation], any[S3ObjectLocation]))
       .thenAnswer((invocation: InvocationOnMock) => {
         val src = invocation.getArgument[S3ObjectLocation](0)
         val dst = invocation.getArgument[S3ObjectLocation](1)


### PR DESCRIPTION
In practice, we always set `checkForExisting=true`, so let's remove the unsafe path where we might overwrite an object without checking first.

Closes https://github.com/wellcomecollection/platform/issues/5647, for https://github.com/wellcomecollection/platform/issues/4785