### PR TITLE
Use the AWS Java V2 SDK for S3, part 1 (use the V2 SDK in tests)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Start using the AWS Java V2 SDK for S3 for testing S3-related code.  This doesn't change any library code.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -177,6 +177,7 @@ object Dependencies {
   val storageDependencies: Seq[ModuleID] = Seq(
     "com.azure" % "azure-storage-blob" % versions.azure,
     "software.amazon.awssdk" % "dynamodb" % versions.aws,
+    "software.amazon.awssdk" % "s3" % versions.aws,
     "com.amazonaws" % "aws-java-sdk-s3" % versions.aws1
   ) ++
     scanamoDependencies ++

--- a/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
+++ b/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
@@ -2,12 +2,6 @@ package weco.storage.fixtures
 
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.iterable.S3Objects
-import com.amazonaws.services.s3.model.{
-  ObjectMetadata,
-  PutObjectRequest,
-  S3ObjectSummary
-}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import grizzled.slf4j.Logging
 import io.circe.parser.parse
@@ -15,6 +9,13 @@ import io.circe.{Decoder, Json}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model._
 import weco.fixtures._
 import weco.json.JsonUtil._
 import weco.storage.generators.{S3ObjectLocationGenerators, StreamGenerators}
@@ -22,7 +23,9 @@ import weco.storage.s3.{S3Config, S3ObjectLocation}
 import weco.storage.streaming.Codec._
 import weco.storage.streaming.InputStreamWithLength
 
+import java.net.URI
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 object S3Fixtures {
   class Bucket(val name: String) extends AnyVal {
@@ -57,34 +60,83 @@ trait S3Fixtures
         new EndpointConfiguration(endpoint, "localhost"))
       .build()
 
+  def createS3ClientV2WithEndpoint(endpoint: String): S3Client =
+    S3Client.builder()
+      .credentialsProvider(
+        StaticCredentialsProvider.create(
+          AwsBasicCredentials.create("accessKey1", "verySecretKey1"))
+      )
+      .forcePathStyle(true)
+      .endpointOverride(new URI(endpoint))
+      .build()
+
   implicit val s3Client: AmazonS3 =
     createS3ClientWithEndpoint(s"http://localhost:$s3Port")
 
   val brokenS3Client: AmazonS3 =
     createS3ClientWithEndpoint("http://nope.nope")
 
+  implicit val s3ClientV2: S3Client =
+    createS3ClientV2WithEndpoint(s"http://localhost:$s3Port")
+
+  val brokenS3ClientV2: S3Client =
+    createS3ClientV2WithEndpoint("http://nope.nope")
+
+  private def doesBucketExist(bucketName: String): Boolean = {
+    // This is based on a method called doesBucketExistV2 in the V1 Java SDK,
+    // which used GetBucketAcl under the hood to check if a bucket existed.
+    val request =
+      GetBucketAclRequest.builder()
+        .bucket(bucketName)
+        .build()
+
+    Try { s3ClientV2.getBucketAcl(request) } match {
+      case Success(_) => true
+      case Failure(e: S3Exception) if e.statusCode() == 404 => false
+      case Failure(e) => throw e
+    }
+  }
+
   def withLocalS3Bucket[R]: Fixture[Bucket, R] =
     fixture[Bucket, R](
       create = {
         eventually {
-          s3Client.listBuckets().asScala.size should be >= 0
+          s3ClientV2.listBuckets().buckets().asScala.size should be >= 0
         }
         val bucketName: String = createBucketName
-        s3Client.createBucket(bucketName)
-        eventually { s3Client.doesBucketExistV2(bucketName) }
+
+        val request =
+          CreateBucketRequest.builder()
+            .bucket(bucketName)
+            .build()
+
+        s3ClientV2.createBucket(request)
+
+        eventually { doesBucketExist(bucketName) }
 
         Bucket(bucketName)
       },
       destroy = { bucket: Bucket =>
-        if (s3Client.doesBucketExistV2(bucket.name)) {
+        if (doesBucketExist(bucket.name)) {
 
           listKeysInBucket(bucket).foreach { key =>
-            safeCleanup(key) {
-              s3Client.deleteObject(bucket.name, _)
+            safeCleanup(key) { _ =>
+              val deleteObjectRequest =
+                DeleteObjectRequest.builder()
+                  .bucket(bucket.name)
+                  .key(key)
+                  .build()
+
+              s3ClientV2.deleteObject(deleteObjectRequest)
             }
           }
 
-          s3Client.deleteBucket(bucket.name)
+          val deleteBucketRequest =
+            DeleteBucketRequest.builder()
+              .bucket(bucket.name)
+              .build()
+
+          s3ClientV2.deleteBucket(deleteBucketRequest)
         } else {
           info(s"Trying to clean up ${bucket.name}, bucket does not exist.")
         }
@@ -92,11 +144,17 @@ trait S3Fixtures
     )
 
   def getContentFromS3(location: S3ObjectLocation): String = {
-    val s3Object = s3Client.getObject(location.bucket, location.key)
+    val getRequest =
+      GetObjectRequest.builder()
+        .bucket(location.bucket)
+        .key(location.key)
+        .build()
+
+    val s3Object = s3ClientV2.getObject(getRequest)
 
     val inputStream = new InputStreamWithLength(
-      s3Object.getObjectContent,
-      length = s3Object.getObjectMetadata.getContentLength
+      s3Object,
+      length = s3Object.response().contentLength()
     )
     stringCodec.fromStream(inputStream).value
   }
@@ -111,17 +169,16 @@ trait S3Fixtures
   def putStream(
     location: S3ObjectLocation,
     inputStream: InputStreamWithLength = createInputStream()): Unit = {
-    val metadata = new ObjectMetadata()
-    metadata.setContentLength(inputStream.length)
+    val putRequest =
+      PutObjectRequest.builder()
+        .bucket(location.bucket)
+        .key(location.key)
+        .contentLength(inputStream.length)
+        .build()
 
-    val putObjectRequest = new PutObjectRequest(
-      location.bucket,
-      location.key,
-      inputStream,
-      metadata
-    )
+    val requestBody = RequestBody.fromInputStream(inputStream, inputStream.length)
 
-    s3Client.putObject(putObjectRequest)
+    s3ClientV2.putObject(putRequest, requestBody)
 
     inputStream.close()
   }
@@ -134,18 +191,19 @@ trait S3Fixtures
     * @param bucket The instance of S3.Bucket to list.
     * @return A list of object keys.
     */
-  def listKeysInBucket(bucket: Bucket): List[String] =
-    S3Objects
-      .inBucket(s3Client, bucket.name)
-      .withBatchSize(1000)
+  def listKeysInBucket(bucket: Bucket): List[String] = {
+    val listRequest =
+      ListObjectsV2Request.builder()
+        .bucket(bucket.name)
+        .build()
+
+    s3ClientV2.listObjectsV2Paginator(listRequest)
       .iterator()
       .asScala
+      .flatMap { resp: ListObjectsV2Response => resp.contents().asScala }
+      .map { s3Obj: S3Object => s3Obj.key() }
       .toList
-      .par
-      .map { objectSummary: S3ObjectSummary =>
-        objectSummary.getKey
-      }
-      .toList
+  }
 
   /** Returns a map (key -> contents) for all objects in an S3 bucket.
     *

--- a/storage/src/test/scala/weco/storage/services/s3/S3LargeStreamReaderTest.scala
+++ b/storage/src/test/scala/weco/storage/services/s3/S3LargeStreamReaderTest.scala
@@ -26,7 +26,7 @@ class S3LargeStreamReaderTest
     createS3ObjectLocationWith(bucket)
 
   override def writeString(location: S3ObjectLocation, contents: String): Unit =
-    s3Client.putObject(location.bucket, location.key, contents)
+    putString(location, contents)
 
   override def withLargeStreamReader[R](
     bufferSize: Long

--- a/storage/src/test/scala/weco/storage/services/s3/S3RangedReaderTest.scala
+++ b/storage/src/test/scala/weco/storage/services/s3/S3RangedReaderTest.scala
@@ -18,7 +18,7 @@ class S3RangedReaderTest
     createS3ObjectLocationWith(bucket)
 
   override def writeString(location: S3ObjectLocation, contents: String): Unit =
-    s3Client.putObject(location.bucket, location.key, contents)
+    putString(location, contents)
 
   override def withRangedReader[R](
     testWith: TestWith[RangedReader[S3ObjectLocation], R]

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -258,7 +258,7 @@ trait DynamoHybridStoreTestCases[
                     val indexedEntry = indexedStore.get(id).value
                     val s3Location = indexedEntry.identifiedT
 
-                    s3Client.deleteObject(s3Location.bucket, s3Location.key)
+                    deleteObject(s3Location)
 
                     val value = hybridStore.get(id).left.value
 
@@ -288,8 +288,8 @@ trait DynamoHybridStoreTestCases[
                     val indexedEntry = indexedStore.get(id).value
                     val s3Location = indexedEntry.identifiedT
 
-                    s3Client.deleteObject(s3Location.bucket, s3Location.key)
-                    s3Client.deleteBucket(s3Location.bucket)
+                    deleteObject(s3Location)
+                    deleteBucket(bucket)
 
                     val value = hybridStore.get(id).left.value
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4785

I don't want to upgrade the library code and the tests at once, because there's a good chance I'll make the same mistake on both sides and miss it. 🙈 

So I'm going to update them in bits. 

This PR updates a bunch of the test code – we make assertions about the state of the S3 container using the V2 SDK – but without changing any of the library code it's testing. I'd like to get this merged and used everywhere as an initial sense check of the V2 SDK, then when I change the library code I'll be testing on slightly more solid ground.