### PR TITLE
Do the multipart upload ourselves, not with TransferManager

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This changes the way S3StreamWritable works internally, so it should work better with our applications – in particular it now uses a blocking S3 client, rather than an asynchronous S3TransferManager, which is a better fit for how we do concurrency elsewhere.

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -46,6 +46,10 @@ object S3Errors {
     case exc: S3Exception if exc.statusCode() == 500 =>
       new StoreWriteError(exc) with RetryableError
 
+    // e.g. S3Exception: Object key is too long. Maximum number of bytes allowed in keys is 915.
+    case exc: S3Exception if exc.getMessage.startsWith("Object key is too long") =>
+      InvalidIdentifierFailure(exc)
+
     case exc => StoreWriteError(exc)
   }
 }

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -47,7 +47,8 @@ object S3Errors {
       new StoreWriteError(exc) with RetryableError
 
     // e.g. S3Exception: Object key is too long. Maximum number of bytes allowed in keys is 915.
-    case exc: S3Exception if exc.getMessage.startsWith("Object key is too long") =>
+    case exc: S3Exception
+        if exc.getMessage.startsWith("Object key is too long") =>
       InvalidIdentifierFailure(exc)
 
     case exc => StoreWriteError(exc)

--- a/storage/src/main/scala/weco/storage/services/s3/S3Uploader.scala
+++ b/storage/src/main/scala/weco/storage/services/s3/S3Uploader.scala
@@ -2,7 +2,6 @@ package weco.storage.services.s3
 
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
-import software.amazon.awssdk.transfer.s3.S3TransferManager
 import weco.storage._
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.s3.S3StreamStore
@@ -16,7 +15,6 @@ import scala.concurrent.duration.Duration
   * pre-signed URL for somebody to GET that string out of the bucket.
   */
 class S3Uploader(implicit val s3Client: S3Client,
-                 s3TransferManager: S3TransferManager,
                  s3Presigner: S3Presigner) {
   import S3ObjectExists._
 

--- a/storage/src/main/scala/weco/storage/services/s3/S3Uploader.scala
+++ b/storage/src/main/scala/weco/storage/services/s3/S3Uploader.scala
@@ -14,8 +14,7 @@ import scala.concurrent.duration.Duration
 /** This class allows you to upload a string to an S3 bucket, and get a
   * pre-signed URL for somebody to GET that string out of the bucket.
   */
-class S3Uploader(implicit val s3Client: S3Client,
-                 s3Presigner: S3Presigner) {
+class S3Uploader(implicit val s3Client: S3Client, s3Presigner: S3Presigner) {
   import S3ObjectExists._
 
   private val presignedUrls = new S3PresignedUrls()

--- a/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
@@ -3,7 +3,13 @@ package weco.storage.store.s3
 import grizzled.slf4j.Logging
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{CompleteMultipartUploadRequest, CompletedMultipartUpload, CompletedPart, CreateMultipartUploadRequest, UploadPartRequest}
+import software.amazon.awssdk.services.s3.model.{
+  CompleteMultipartUploadRequest,
+  CompletedMultipartUpload,
+  CompletedPart,
+  CreateMultipartUploadRequest,
+  UploadPartRequest
+}
 import weco.storage.s3.S3ObjectLocation
 
 import scala.collection.JavaConverters._
@@ -31,7 +37,10 @@ trait S3MultipartUploader extends Logging {
       createResponse.uploadId()
     }
 
-  def uploadPart(location: S3ObjectLocation, uploadId: String, bytes: Array[Byte], partNumber: Int): Try[CompletedPart] =
+  def uploadPart(location: S3ObjectLocation,
+                 uploadId: String,
+                 bytes: Array[Byte],
+                 partNumber: Int): Try[CompletedPart] =
     Try {
       val uploadPartRequest =
         UploadPartRequest
@@ -54,7 +63,9 @@ trait S3MultipartUploader extends Logging {
         .build()
     }
 
-  def completeMultipartUpload(location: S3ObjectLocation, uploadId: String, completedParts: List[CompletedPart]): Try[Unit] =
+  def completeMultipartUpload(location: S3ObjectLocation,
+                              uploadId: String,
+                              completedParts: List[CompletedPart]): Try[Unit] =
     Try {
       val completedMultipartUpload =
         CompletedMultipartUpload

--- a/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
@@ -1,0 +1,76 @@
+package weco.storage.store.s3
+
+import grizzled.slf4j.Logging
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{CompleteMultipartUploadRequest, CompletedMultipartUpload, CompletedPart, CreateMultipartUploadRequest, UploadPartRequest}
+import weco.storage.s3.S3ObjectLocation
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+trait S3MultipartUploader extends Logging {
+  implicit val s3Client: S3Client
+
+  /** Starts a multipart upload and returns the multipart upload ID */
+  def createMultipartUpload(location: S3ObjectLocation): Try[String] =
+    Try {
+      val createRequest =
+        CreateMultipartUploadRequest
+          .builder()
+          .bucket(location.bucket)
+          .key(location.key)
+          .build()
+
+      val createResponse = s3Client.createMultipartUpload(createRequest)
+
+      debug(
+        s"Got CreateMultipartUploadResponse to $location with upload ID ${createResponse.uploadId()}"
+      )
+
+      createResponse.uploadId()
+    }
+
+  def uploadPart(location: S3ObjectLocation, uploadId: String, bytes: Array[Byte], partNumber: Int): Try[CompletedPart] =
+    Try {
+      val uploadPartRequest =
+        UploadPartRequest
+          .builder()
+          .bucket(location.bucket)
+          .key(location.key)
+          .uploadId(uploadId)
+          .partNumber(partNumber)
+          .build()
+
+      val requestBody = RequestBody.fromBytes(bytes)
+
+      val uploadPartResponse =
+        s3Client.uploadPart(uploadPartRequest, requestBody)
+
+      CompletedPart
+        .builder()
+        .eTag(uploadPartResponse.eTag())
+        .partNumber(partNumber)
+        .build()
+    }
+
+  def completeMultipartUpload(location: S3ObjectLocation, uploadId: String, completedParts: List[CompletedPart]): Try[Unit] =
+    Try {
+      val completedMultipartUpload =
+        CompletedMultipartUpload
+          .builder()
+          .parts(completedParts.asJava)
+          .build()
+
+      val completeRequest =
+        CompleteMultipartUploadRequest
+          .builder()
+          .bucket(location.bucket)
+          .key(location.key)
+          .uploadId(uploadId)
+          .multipartUpload(completedMultipartUpload)
+          .build()
+
+      s3Client.completeMultipartUpload(completeRequest)
+    }
+}

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamStore.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamStore.scala
@@ -1,13 +1,12 @@
 package weco.storage.store.s3
 
+import org.apache.commons.io.FileUtils
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.transfer.s3.S3TransferManager
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.StreamStore
 
-class S3StreamStore(val maxRetries: Int = 2)(
-  implicit val s3Client: S3Client,
-  val transferManager: S3TransferManager)
+class S3StreamStore(val maxRetries: Int = 2, val partSize: Long = 128 * FileUtils.ONE_MB)(
+  implicit val s3Client: S3Client)
     extends StreamStore[S3ObjectLocation]
     with S3StreamReadable
     with S3StreamWritable

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamStore.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamStore.scala
@@ -5,8 +5,9 @@ import software.amazon.awssdk.services.s3.S3Client
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.StreamStore
 
-class S3StreamStore(val maxRetries: Int = 2, val partSize: Long = 128 * FileUtils.ONE_MB)(
-  implicit val s3Client: S3Client)
+class S3StreamStore(
+  val maxRetries: Int = 2,
+  val partSize: Long = 128 * FileUtils.ONE_MB)(implicit val s3Client: S3Client)
     extends StreamStore[S3ObjectLocation]
     with S3StreamReadable
     with S3StreamWritable

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
@@ -64,13 +64,15 @@ trait S3StreamWritable
       }
 
       if (partNumber == partCount && inputStream.available() > 0) {
-        throw new RuntimeException(s"Not all bytes read from input stream: read ${inputStream.length} bytes, but ${inputStream.available()} bytes still available")
+        throw new RuntimeException(
+          s"Not all bytes read from input stream: read ${inputStream.length} bytes, but ${inputStream
+            .available()} bytes still available")
       }
 
       uploadPart(location, uploadId, bytes, partNumber)
     }.toList
 
-    val successes = result.collect { case Success(s) => s }
+    val successes = result.collect { case Success(s)     => s }
     val failures = result.collectFirst { case Failure(e) => e }
 
     failures match {

--- a/storage/src/main/scala/weco/storage/store/s3/S3TypedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3TypedStore.scala
@@ -1,7 +1,6 @@
 package weco.storage.store.s3
 
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.transfer.s3.S3TransferManager
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.TypedStore
 import weco.storage.streaming.Codec
@@ -13,8 +12,7 @@ class S3TypedStore[T](
 
 object S3TypedStore {
   def apply[T](implicit codec: Codec[T],
-               s3Client: S3Client,
-               transferManager: S3TransferManager): S3TypedStore[T] = {
+               s3Client: S3Client): S3TypedStore[T] = {
     implicit val streamStore: S3StreamStore = new S3StreamStore()
 
     new S3TypedStore[T]()

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -206,8 +206,7 @@ trait DynamoHybridStoreTestCases[
                 val value = result.left.value
 
                 value shouldBe a[InvalidIdentifierFailure]
-                value.e.getMessage should startWith(
-                  "S3 object key byte length is too big")
+                value.e.getMessage should startWith("Object key is too long")
               }
             }
           }

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
@@ -68,7 +68,7 @@ class S3StreamStoreTest
     }
 
     describe("put") {
-      it("errors if S3 fails to respond") { 
+      it("errors if S3 fails to respond") {
         val store = new S3StreamStore()(brokenS3Client)
 
         val result = store.put(createS3ObjectLocation)(createT).left.value
@@ -121,8 +121,7 @@ class S3StreamStoreTest
             val value = store.put(id)(entry).left.value
 
             value shouldBe a[InvalidIdentifierFailure]
-            value.e.getMessage should startWith(
-              "S3 object key byte length is too big")
+            value.e.getMessage should startWith("Object key is too long")
           }
         }
       }

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
@@ -1,12 +1,16 @@
 package weco.storage.store.s3
 
+import java.io.ByteArrayInputStream
+
+import org.apache.commons.io.FileUtils
 import software.amazon.awssdk.core.exception.SdkClientException
-import software.amazon.awssdk.services.s3.model.S3Exception
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, S3Exception}
 import weco.storage.fixtures.S3Fixtures.Bucket
 import weco.storage.store.StreamStoreTestCases
 import weco.storage._
 import weco.storage.s3.S3ObjectLocation
 import weco.storage.store.fixtures.S3NamespaceFixtures
+import weco.storage.streaming.InputStreamWithLength
 
 class S3StreamStoreTest
     extends StreamStoreTestCases[S3ObjectLocation, Bucket, S3StreamStore, Unit]
@@ -15,7 +19,7 @@ class S3StreamStoreTest
   describe("handles errors from S3") {
     describe("get") {
       it("errors if S3 has a problem") {
-        val store = new S3StreamStore()(brokenS3Client, brokenS3TransferManager)
+        val store = new S3StreamStore()(brokenS3Client)
 
         val result = store.get(createS3ObjectLocation).left.value
         result shouldBe a[StoreReadError]
@@ -64,8 +68,8 @@ class S3StreamStoreTest
     }
 
     describe("put") {
-      it("errors if S3 fails to respond") {
-        val store = new S3StreamStore()(brokenS3Client, brokenS3TransferManager)
+      it("errors if S3 fails to respond") { 
+        val store = new S3StreamStore()(brokenS3Client)
 
         val result = store.put(createS3ObjectLocation)(createT).left.value
         result shouldBe a[StoreWriteError]
@@ -122,6 +126,29 @@ class S3StreamStoreTest
           }
         }
       }
+    }
+  }
+
+  it("uploads a large file (>partSize)") {
+    val length = (10 * FileUtils.ONE_MB).toInt + 1
+
+    val bytes = randomBytes(length)
+    val inputStream = new ByteArrayInputStream(bytes.toArray)
+    val store = new S3StreamStore(partSize = length - 1)
+
+    withLocalS3Bucket { bucket =>
+      val location = createS3ObjectLocationWith(bucket)
+
+      val result = store.put(location)(new InputStreamWithLength(inputStream, length))
+      result shouldBe a[Right[_, _]]
+
+      val getRequest =
+        GetObjectRequest.builder()
+          .bucket(location.bucket)
+          .key(location.key)
+          .build()
+
+      s3Client.getObjectAsBytes(getRequest).asByteArray() shouldBe bytes
     }
   }
 }

--- a/storage/src/test/scala/weco/storage/store/s3/S3TypedStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3TypedStoreTest.scala
@@ -74,8 +74,7 @@ class S3TypedStoreTest
           val value = store.put(location)(entry).left.value
 
           value shouldBe a[InvalidIdentifierFailure]
-          value.e.getMessage should startWith(
-            "S3 object key byte length is too big")
+          value.e.getMessage should startWith("Object key is too long")
         }
       }
     }


### PR DESCRIPTION
There's a test in https://github.com/wellcomecollection/storage-service/pull/1046 that hangs forever. We have a collection of input streams in a sequence:

```mermaid
graph TD
   S3[InputStream from truncated_header.tar.gz] --> U[gzip-uncompressed InputStream of truncated_header.tar]
   U --> B[InputStream from individual tar entry 9.bin]
   B --> Up[being uploaded to S3 through TransferManager]
```

but the individual tar entry `9.bin` is truncated. This should be throwing an EOF exception, but for some reason the S3 client is hanging, waiting forever for more bytes that will never come. I think the exception is being swallowed somewhere inside the S3 TransferManager concurrency model, which uses a Java ExecutorService and I don't really understand properly.

I think we can skip using S3TransferManager, and do the multipart upload ourselves. 99% of the "new" code in this PR comes from the snapshot generator, where we already do this – the only difference is that we don't know the size of a snapshot in advance; we have to just keep creating new parts as we need them. Here, we know how big the object should be in advance, so we know up front how many parts we'll need.

This passes with all the existing S3 tests in scala-libs, and I've confirmed it works in the failing storage service test also.

Here's the corresponding code in the snapshot generator: https://github.com/wellcomecollection/catalogue-api/blob/main/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/storage/S3Uploader.scala