### PR TITLE
Retry instances of java.net.SocketException

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Retry instances of `java.net.SocketException` when reading from S3.

--- a/storage/src/main/scala/weco/storage/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/s3/S3Errors.scala
@@ -4,7 +4,7 @@ import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.services.s3.model.S3Exception
 import weco.storage._
 
-import java.net.{SocketTimeoutException, UnknownHostException}
+import java.net.{SocketException, SocketTimeoutException, UnknownHostException}
 
 object S3Errors {
   val readErrors: PartialFunction[Throwable, ReadError] = {
@@ -34,6 +34,10 @@ object S3Errors {
 
     case exc: SdkClientException
         if exc.getCause.isInstanceOf[UnknownHostException] =>
+      new StoreReadError(exc) with RetryableError
+
+    // e.g. java.net.SocketException: Connection reset
+    case exc: SocketException =>
       new StoreReadError(exc) with RetryableError
 
     case exc: SocketTimeoutException =>


### PR DESCRIPTION
We had a bag fail to store in the storage service this weekend: https://wellcome-ingest-inspector.glitch.me/ingests/fb606b49-71e8-4cad-9fd7-c571324f7fdb

If you look in the application logs, you see this error:

> weco.storage.services.LargeStreamReaderCannotReadRange: Unable to read range OpenByteRange(0) from s3://wellcomecollection-storage-replica-ireland/digitised/b10777349/v1/data/objects/b10777349_0170.jp2: java.net.SocketException: Connection reset

Transient errors like this are going to happen, so we just need to make sure we retry correctly. It's plausible this is connected to the AWS Java V2 SDK upgrade (https://github.com/wellcomecollection/platform/issues/4785), but I don't think it's a big issue.