### PR TITLE
Restore the CRT libraries, because we need them for the bag replicator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Restore the AWS CRT libraries, because their absence is causing the bag replicator to fail when transferring files >5GB in size.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,11 @@ object Dependencies {
 
     val aws = "2.19.0"
 
+    // These are the "Common Runtime Libraries", which you're encouraged to use for
+    // better performance.
+    // See https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html
+    val awsCrt = "0.20.3"
+
     val azure = "12.7.0"
 
     val circe = "0.14.2"
@@ -176,6 +181,7 @@ object Dependencies {
     "software.amazon.awssdk" % "dynamodb" % versions.aws,
     "software.amazon.awssdk" % "s3" % versions.aws,
     "software.amazon.awssdk" % "s3-transfer-manager" % versions.aws,
+    "software.amazon.awssdk.crt" % "aws-crt" % versions.awsCrt
   ) ++
     scanamoDependencies ++
     apacheCommons


### PR DESCRIPTION
Without them, we can't copy files which are more than 5GB in size – which we have in our A/V bags. See https://github.com/wellcomecollection/storage-service/issues/1066

Reverts https://github.com/wellcomecollection/scala-libs/pull/214