### PR TITLE
update versions for logging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Update logging dependencies.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,8 @@ object Dependencies {
     val circe = "0.14.5"
     val circeGenericExtras = "0.14.3"
 
-    val typesafe = "1.3.2"
-    val logback = "1.1.8"
+    val typesafe = "1.4.2"
+    val logback = "1.4.7"
     val mockito = "1.10.19"
     val scalatest = "3.2.3"
     val scalatestPlus = "3.1.2.0"
@@ -22,7 +22,7 @@ object Dependencies {
     val apacheCommons = "2.6"
 
     // Provides slf4j-api
-    val grizzled = "1.3.2"
+    val grizzled = "1.3.4"
 
     // This has to match the version of akka used by elastic4s
     // Otherwise we get errors like:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,4 @@ addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.15")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
+addDependencyTreePlugin


### PR DESCRIPTION
The jump to slf4j 2.0.7 has broken logging due to incompatibility with the logging provider.  This should fix it.