### PR TITLE
Refresh the token if Sierra returns an invalid grant

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Refresh the auth token and retry requests once if the SierraOauthHttpClient returns a 401 with description "invalid_grant"

--- a/http/src/main/scala/weco/http/client/TokenExchange.scala
+++ b/http/src/main/scala/weco/http/client/TokenExchange.scala
@@ -15,9 +15,9 @@ trait TokenExchange[C, T] {
 
   protected def getNewToken(credentials: C): Future[(T, Instant)]
 
-  def getToken(credentials: C): Future[T] =
-    cachedToken match {
-      case Some((token, expiryTime))
+  def getToken(credentials: C, forceRefresh: Boolean = false): Future[T] =
+    (cachedToken, forceRefresh) match {
+      case (Some((token, expiryTime)), false)
           if expiryTime
             .minusSeconds(expiryGracePeriod.toSeconds)
             .isAfter(Instant.now()) =>


### PR DESCRIPTION
Didn't want to mess with all `TokenExchange`s so this is just for Sierra