### PR TITLE
Bump the SBT version from 1.4.1 to 1.9.8

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Use sbt v1.9.8 to avoid build issues on M1 macs.
+
+See https://github.com/wellcomecollection/scala-libs/pull/236

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.15")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
 addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

> [!NOTE]
> This PR follows https://github.com/wellcomecollection/catalogue-api/pull/737 which does the same thing!

The 1.4.1 version of SBT has an issue with the version of the JNA library is uses which prevents it from loading on M1 macs.

```console
➜  scala-libs git:(main) ✗ sbt
copying runtime jar...
[info] [launcher] getting org.scala-sbt sbt 1.4.1  (this may take some time)...
[info] [launcher] getting Scala 2.12.12 (for sbt)...
java.lang.UnsatisfiedLinkError: Can't load library: /Users/kennyr/Library/Caches/JNA/temp/jna12269094481575250405.tmp
```

See: https://github.com/sbt/io/issues/320

## How to test?

The most recent version (1.9.8) of sbt seems to work with this project, so upgrading.

- [ ] Build and test locally, does it succeed?
- [ ] Does this PR get a green tick when running in CI?

## How can we measure success?

People working on this project with M1 macs can build and test it.

## Have we considered potential risks?

Jumping from 1.4.x to 1.9.x is a large version leap ... there may be some breaking changes [lurking in the release notes](https://github.com/sbt/sbt/releases). However if the project builds and tests without error we can be somewhat reassured that we have not met any.