### PR TITLE
Exclude transitive dependency on pre 5.7 version of JNA

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Update elastic APM libraries, needed to avoid JNA issue on M1 macs.
+
+See https://github.com/wellcomecollection/scala-libs/pull/236

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val versions = new {
-    val elasticApm = "1.45.0"
+    val elasticApm = "1.22.0"
     val elastic4s = "8.8.1"
 
     val aws = "2.19.0"
@@ -136,7 +136,11 @@ object Dependencies {
   )
 
   val elasticApmAgentDependencies = Seq(
-    "co.elastic.apm" % "apm-agent-attach" % versions.elasticApm,
+    "co.elastic.apm" % "apm-agent-attach" % versions.elasticApm
+      // This needs to be excluded because it prevents this library functioning on M1 macs
+      // at the current version of apm-agent-attach it pulls in version 5.3.1 of jna,
+      // we need at least 5.7 to fix this issue. See https://github.com/java-native-access/jna/pull/1238
+      exclude("net.java.dev.jna", "jna"),
     "co.elastic.apm" % "apm-agent-api" % versions.elasticApm,
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val versions = new {
-    val elasticApm = "1.22.0"
+    val elasticApm = "1.45.0"
     val elastic4s = "8.8.1"
 
     val aws = "2.19.0"


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/scala-libs/pull/236, and required for the same reason. We are still pulling in an old version of the JNA library causing this issue (pre 5.7), see:

- https://github.com/java-native-access/jna/blob/master/CHANGES.md#release-570
- https://github.com/java-native-access/jna/pull/1238

We exclude the JNA lib as a transitive dep, which avoids packaging it and blowing up downstream consumers.

https://github.com/elastic/apm-agent-java/blob/be8add66d074febe16748691725b6cfe69f238d0/docs/setup-attach-api.asciidoc

Using `publishLocal` to try this out locally before release and running a project that incorporates this dependency where we've seen this issue, the runtime error is fixed and we can see the dependency excluded.

Resolves this issue: https://github.com/wellcomecollection/catalogue-api/pull/737#issuecomment-1890956599

See the dep being excluded (jna-platform is still there, but jna is excluded).
![Screenshot 2024-01-19 at 16 02 41](https://github.com/wellcomecollection/scala-libs/assets/953792/03f3c646-c340-4482-a5a8-99913f0363b8)

## How to test

- [x] Tests pass?
- [x] Consumers are free from error when trying to run projects that include this library on M1 macs.

## How can we measure success?

Developers can run projects locally on their machines without issue.

## Have we considered potential risks?

It's possible we hit one of the special conditions described in the [caveats](https://github.com/elastic/apm-agent-java/blob/be8add66d074febe16748691725b6cfe69f238d0/docs/setup-attach-api.asciidoc#caveats). We'll see this if consumers fail!
