### PR TITLE
Add a dependency on jna 5.7 to provide a mac compatible version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Adds a dependency on a jre compatible version of jna for apm, whatever that means.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -144,6 +144,14 @@ object Dependencies {
     "co.elastic.apm" % "apm-agent-api" % versions.elasticApm,
   )
 
+  // This is required to provide a version of jna to consumers of the apm library,
+  // when running in a jre (as specified in Dockerfiles for deployable images).
+  // See https://github.com/elastic/apm-agent-java/issues/2353 for an explanation
+  // of the issue this addresses.
+  val jnaDependencies: Seq[ModuleID] = Seq(
+    "net.java.dev.jna" % "jna" % "5.7.0"
+  )
+
   val localstackDependencies = Seq(
     "software.amazon.awssdk" % "auth" % versions.aws,
     "software.amazon.awssdk" % "regions" % versions.aws
@@ -160,7 +168,7 @@ object Dependencies {
     "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % versions.akkaStreamAlpakka
     // This needs to be excluded because it conflicts with aws http client "netty-nio-client"
     // and it also causes weird leaks between tests
-      exclude ("com.github.matsluni", "aws-spi-akka-http_2.12")
+      exclude("com.github.matsluni", "aws-spi-akka-http_2.12")
   ) ++
     testDependencies
 
@@ -179,6 +187,7 @@ object Dependencies {
       loggingDependencies ++
       typesafeDependencies ++
       elasticApmAgentDependencies ++
+      jnaDependencies ++
       testDependencies
 
   val storageDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
## What does this change?

Previously we excluded the transitive JNA dependency (https://github.com/wellcomecollection/scala-libs/pull/237) as it is not required where we are using a JDK, however our deployed container images use a JRE only to reduce the container footprint, this doesn't work where the JNA dependency is excluded and causes runtime errors (as indicated in [the elastic-apm docs](https://github.com/elastic/apm-agent-java/blob/be8add66d074febe16748691725b6cfe69f238d0/docs/setup-attach-api.asciidoc#caveats)).

This is in service of being able to run our Scala apps locally more easily in general in order to better test and debug their behaviour (this is a blocker to doing that).

See https://github.com/wellcomecollection/catalogue-api/pull/743 for the offending PR and error.

## How to test

- [x] `publishLocal` the `typesafe_app` library, and attempt to run a dependent app in a JRE only environment e.g. `./builds/run_sbt_task_in_docker.sh "project items" "run"` in https://github.com/wellcomecollection/catalogue-api.

## How can we measure success?

Can we:

- [ ] Run consumers locally without this error
- [ ] Run consumers in production / staging with only a JRE

## Have we considered potential risks?

We are using a version of JNA not explicitly compatible with the elastic apm agent, that may cause other unexpected issues.
