### PR TITLE
Send the Scala dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,19 @@
+# .github/workflows/dependency-graph.yml
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - rk/scala-dep-graph
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,7 +3,7 @@ name: Update Dependency Graph
 on:
   push:
     branches:
-      - rk/scala-dep-graph
+      - main
 
 permissions:
   id-token: write


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-api/pull/766 this change pushes the scala dependency graph to the GitHub API to surface vulnerabilities.

We don't need access to S3 as with other similar pull requests as we're not pulling our own deps (we build them here).

Part of https://github.com/wellcomecollection/platform-infrastructure/issues/431

## How to test

- [x] Does the build go green, can we see the dep graph after merging?

## How can we measure success?

Visibility on dependencies and vulnerabilities. In this repository it's especially useful as this is a shared scala-lib used ina few places.

## Have we considered potential risks?

This change should help manage / reduce risk.