### PR TITLE
Bump up aws

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,2 @@
+RELEASE_TYPE: minor
+Bump aws to v2.25.28

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val elasticApm = "1.22.0"
     val elastic4s = "8.8.1"
 
-    val aws = "2.19.0"
+    val aws = "2.25.28"
 
     // Note: this should probably match the version of Circe used by elastic4s.
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala


### PR DESCRIPTION
## What does this change?

This pushes the version of AWS to v2.25.28

## How to test

The project builds and tests all pass 

## How can we measure success?

Once released and installed in storage-service, some performance improvements could make storing large bags more reliable

## Have we considered potential risks?

This is a minor update, other projects that use scala-libs should be unaffected
