### PR TITLE
Add location to sierra source required item fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+    Add location to Sierrasource's requiredItemFields

--- a/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
+++ b/sierra/src/main/scala/weco/sierra/http/SierraSource.scala
@@ -234,7 +234,8 @@ object SierraSource {
     "holdCount",
     "suppressed",
     "status",
-    "varFields"
+    "varFields",
+    "location"
   )
 
   // cf. the fields in the case class `SierraHold`


### PR DESCRIPTION
## What does this change?

As part of the offsite requesting work, we need to pull in the item's location from Sierra.
This adds `location` to the list of `requiredItemFields` that Sierra will include in the response 

## How to test

It seems the existing tests are simply testing that the mock data is returned by the mock in-memory Sierra source
I do not know how we can better test that the request we send Sierra is valid and results in the expected response

You can get a Sierra token from `https://libsys.wellcomelibrary.org/iii/sierra-api/v5/token` by setting a Basic Auth header with the username and password stored in AWS secret manager (catalogue account) 

GET item from `https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1469576` using the Bearer token returned above
No further query params will get you all the default fields, same as using `?fields=default` 
```
{
    "id": "1469576",
    "updatedDate": "2016-02-10T10:49:12Z",
    "createdDate": "2001-09-19T14:11:20Z",
    "deleted": false,
    "bibIds": [
        "1091563"
    ],
    "location": {
        "code": "sepin",
        "name": "Closed stores EPB Incunabula"
    },
    "status": {
        "code": "-",
        "display": "Available"
    },
    "volumes": [],
    "callNumber": "3.e.2 (SR)"
}
```
However if you start specifying fields (as `SierraSource` does) the default disappear and you need to list all the required fields, including the ones that are `default`.
BEFORE: the location is not included in the response -> `https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1469576?fields=deleted,fixedFields,holdCount,suppressed,status,varFields`
AFTER the location is included in the response-> `https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1469576?fields=deleted,fixedFields,holdCount,suppressed,status,varFields,location`

## How can we measure success?

Once installed in the catalogue-api, this version of scala-libs will enable us to request item location from Sierra itemsAPI

## Have we considered potential risks?

- The tests don't give me great confidence that this is working as expected, but testing the sierra api directly does
- ~~The previous version of scala-libs, upgrading the AWS SDK, is not used in the catalogue-api yet. This might be a bit fiddly.~~ Actually not that fiddly https://github.com/wellcomecollection/catalogue-api/pull/789

