### PR TITLE
Update Alpakka to version 4.0.0 (#2678)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+    Update Scala to version 2.13.14
+    Update Scanamo to version 1.0.4
+    Update Alpakka to version 4.0.0
+    See https://github.com/wellcomecollection/catalogue-pipeline/issues/2678 for more information
+    
+    

--- a/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
+++ b/elasticsearch/src/main/scala/weco/elasticsearch/ElasticClientBuilder.scala
@@ -11,7 +11,7 @@ import org.apache.http.message.BasicHeader
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 private class ElasticHttpClientApiKeyConfig(encodedApiKey: String,
                                             apiCompatibleWith: Option[String])

--- a/fixtures/src/test/scala/weco/fixtures/LocalResources.scala
+++ b/fixtures/src/test/scala/weco/fixtures/LocalResources.scala
@@ -3,6 +3,7 @@ package weco.fixtures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.io.FileNotFoundException
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
@@ -10,16 +11,15 @@ trait LocalResources {
 
   /** Returns the contents of a file in the "resources" folder. */
   def readResource(name: String): String = {
-    val resource = Source.fromResource(name)
-
     Try {
+      val resource = Source.fromResource(name)
       resource.getLines()
     } match {
       case Success(lines) => lines.mkString("\n")
 
-      case Failure(_: NullPointerException) if name.startsWith("/") =>
+      case Failure(_: FileNotFoundException) if name.startsWith("/") =>
         throw new RuntimeException(s"Could not find resource `$name`; try removing the leading slash")
-      case Failure(_: NullPointerException) =>
+      case Failure(_: FileNotFoundException) =>
         throw new RuntimeException(s"Could not find resource `$name`")
 
       case Failure(e) => throw e

--- a/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
+++ b/http/src/main/scala/weco/http/client/MemoryHttpClient.scala
@@ -19,7 +19,7 @@ class MemoryHttpClient(
   implicit val ec: ExecutionContext
 ) extends HttpClient {
 
-  private val iterator = responses.toIterator
+  private val iterator = responses.iterator
 
   override def singleRequest(request: HttpRequest): Future[HttpResponse] =
     Future {
@@ -61,7 +61,7 @@ class MemoryHttpClient(
   private def getEntityString(entity: HttpEntity): String =
     entity match {
       case HttpEntity.Strict(ContentTypes.`application/json`, json) =>
-        parse(json.utf8String).right.get.spaces2
+        parse(json.utf8String).toOption.get.spaces2
       case HttpEntity.Strict(_, content) => content.utf8String
       case _                             => "<streaming entity>"
     }

--- a/messaging/src/main/scala/weco/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/weco/messaging/sqs/SQSStream.scala
@@ -14,7 +14,7 @@ import weco.json.JsonUtil.fromJson
 import weco.json.exceptions.JsonDecodingError
 import weco.monitoring.Metrics
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 // Provides a stream for processing SQS messages.
 //
@@ -37,7 +37,7 @@ class SQSStream[T](
   metricsSender: Metrics[Future])(implicit val actorSystem: ActorSystem)
     extends Logging {
 
-  implicit val dispatcher = actorSystem.dispatcher
+  implicit val dispatcher: ExecutionContextExecutor = actorSystem.dispatcher
 
   private val source: Source[Message, NotUsed] =
     SqsSource(sqsConfig.queueUrl)(sqsClient)
@@ -122,7 +122,7 @@ class SQSStream[T](
     exception match {
       case exception: JsonDecodingError =>
         logger.warn(s"JSON decoding error: ${exception.getMessage}")
-      case exception: Exception =>
+      case exception: Throwable =>
         logger.error(
           s"Unrecognised failure while: ${exception.getMessage}",
           exception)

--- a/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/weco/messaging/fixtures/SQS.scala
@@ -14,7 +14,7 @@ import weco.messaging.sqs._
 import weco.monitoring.Metrics
 import weco.monitoring.memory.MemoryMetrics
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -240,7 +240,7 @@ trait SQS
       }
       .get
       .messages()
-      .asScala
+      .asScala.toSeq
 
   def createSQSConfigWith(queue: Queue): SQSConfig =
     SQSConfig(queueUrl = queue.url)

--- a/monitoring/src/main/scala/weco/monitoring/Metrics.scala
+++ b/monitoring/src/main/scala/weco/monitoring/Metrics.scala
@@ -1,7 +1,5 @@
 package weco.monitoring
 
-import scala.language.higherKinds
-
 trait Metrics[F[_]] {
   def incrementCount(metricName: String): F[Unit]
   def recordValue(metricName: String, value: Double): F[Unit]

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,9 +16,9 @@ object Common {
       "-Xlint",
       "-Xverify",
       "-Xfatal-warnings",
-      "-Ypartial-unification",
       "-feature",
-      "-language:postfixOps"
+      "-language:postfixOps",
+      "-Xlint:-byname-implicit"
     ),
     parallelExecution in Test := false,
     publishMavenStyle := true,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -6,7 +6,7 @@ import sbt._
 
 object Common {
   def createSettings(projectVersion: String): Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.13.14",
     organization := "weco",
     scalacOptions ++= Seq(
       "-deprecation",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val scalatest = "3.2.3"
     val scalatestPlus = "3.1.2.0"
     val scalatestPlusMockitoArtifactId = "mockito-3-2"
-    val scanamo = "1.0-M13"
+    val scanamo = "1.0.4"
     val apacheCommons = "2.6"
 
     // Provides slf4j-api
@@ -35,7 +35,7 @@ object Dependencies {
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala
     //
     val akka = "2.6.20"
-    val akkaStreamAlpakka = "3.0.4"
+    val akkaStreamAlpakka = "4.0.0"
 
     // Getting the akka-http dependencies right can be fiddly and takes some work.
     // In particular you need to use the same version of akka-http everywhere, or you
@@ -65,7 +65,7 @@ object Dependencies {
     //
     //    java.lang.NoClassDefFoundError: scala/reflect/internal/Names$Name
     //
-    val scalaReflectVersion = "2.12.15"
+    val scalaReflectVersion = "2.13.8"
   }
 
   val circeDependencies = Seq(

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraMaterialType.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraMaterialType.scala
@@ -5,10 +5,11 @@ import io.circe.Decoder
 case class SierraMaterialType(code: String)
 
 object SierraMaterialType {
-  implicit val decoder: Decoder[SierraMaterialType] = Decoder.instance[SierraMaterialType](cursor =>
-    for {
-      id <- cursor.downField("code").as[String]
-    } yield {
-      SierraMaterialType(id.trim)
-  })
+  implicit val decoder: Decoder[SierraMaterialType] =
+    Decoder.instance[SierraMaterialType](cursor =>
+      for {
+        id <- cursor.downField("code").as[String]
+      } yield {
+        SierraMaterialType(id.trim)
+    })
 }

--- a/sierra/src/main/scala/weco/sierra/models/fields/SierraMaterialType.scala
+++ b/sierra/src/main/scala/weco/sierra/models/fields/SierraMaterialType.scala
@@ -5,7 +5,7 @@ import io.circe.Decoder
 case class SierraMaterialType(code: String)
 
 object SierraMaterialType {
-  implicit val decoder = Decoder.instance[SierraMaterialType](cursor =>
+  implicit val decoder: Decoder[SierraMaterialType] = Decoder.instance[SierraMaterialType](cursor =>
     for {
       id <- cursor.downField("code").as[String]
     } yield {

--- a/sierra/src/main/scala/weco/sierra/models/identifiers/TypedSierraRecordNumber.scala
+++ b/sierra/src/main/scala/weco/sierra/models/identifiers/TypedSierraRecordNumber.scala
@@ -45,7 +45,7 @@ sealed trait TypedSierraRecordNumber extends SierraRecordNumber {
     */
   private def getCheckDigit: String = {
     val remainder = recordNumber.reverse
-      .zip(Stream from 2)
+      .zip(LazyList from 2)
       .map { case (char: Char, count: Int) => char.toString.toInt * count }
       .sum % 11
     if (remainder == 10) "x" else remainder.toString

--- a/storage/src/main/scala/weco/storage/locking/LockingService.scala
+++ b/storage/src/main/scala/weco/storage/locking/LockingService.scala
@@ -5,8 +5,6 @@ import cats.data._
 import grizzled.slf4j.Logging
 
 import scala.annotation.tailrec
-import scala.language.higherKinds
-
 trait LockingService[Out, OutMonad[_], LockDaoImpl <: LockDao[_, _]]
     extends Logging {
 

--- a/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockDao.scala
+++ b/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockDao.scala
@@ -13,7 +13,6 @@ import weco.storage.locking.{LockDao, LockFailure, UnlockFailure}
 import weco.storage.dynamo.DynamoTimeFormat._
 
 import scala.concurrent.ExecutionContext
-import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 
 class DynamoLockDao(

--- a/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockDaoConfig.scala
+++ b/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockDaoConfig.scala
@@ -1,7 +1,6 @@
 package weco.storage.locking.dynamo
 
 import weco.storage.dynamo.DynamoConfig
-import weco.storage.dynamo.DynamoConfig
 
 import scala.concurrent.duration.Duration
 

--- a/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockingService.scala
+++ b/storage/src/main/scala/weco/storage/locking/dynamo/DynamoLockingService.scala
@@ -4,8 +4,6 @@ import java.util.UUID
 
 import weco.storage.locking.{LockDao, LockingService}
 
-import scala.language.higherKinds
-
 class DynamoLockingService[Out, OutMonad[_]](
   implicit val lockDao: DynamoLockDao)
     extends LockingService[Out, OutMonad, LockDao[String, UUID]] {

--- a/storage/src/main/scala/weco/storage/locking/memory/MemoryLockingService.scala
+++ b/storage/src/main/scala/weco/storage/locking/memory/MemoryLockingService.scala
@@ -3,9 +3,6 @@ package weco.storage.locking.memory
 import java.util.UUID
 
 import weco.storage.locking.{LockDao, LockingService}
-
-import scala.language.higherKinds
-
 class MemoryLockingService[Out, OutMonad[_]](
   implicit val lockDao: MemoryLockDao[String, UUID])
     extends LockingService[Out, OutMonad, LockDao[String, UUID]] {

--- a/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
+++ b/storage/src/main/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaxima.scala
@@ -6,8 +6,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import weco.storage.dynamo.DynamoHashRangeEntry
 import weco.storage.maxima.Maxima
 import weco.storage.{Identified, MaximaReadError, NoMaximaValueError, Version}
-import weco.storage.dynamo.DynamoHashRangeEntry
-import weco.storage.maxima.Maxima
 
 import scala.util.{Failure, Success, Try}
 

--- a/storage/src/main/scala/weco/storage/store/StreamStore.scala
+++ b/storage/src/main/scala/weco/storage/store/StreamStore.scala
@@ -1,6 +1,5 @@
 package weco.storage.store
 
 import weco.storage.streaming.InputStreamWithLength
-import weco.storage.streaming.InputStreamWithLength
 
 trait StreamStore[Ident] extends Store[Ident, InputStreamWithLength]

--- a/storage/src/main/scala/weco/storage/store/dynamo/DynamoVersionedHybridStore.scala
+++ b/storage/src/main/scala/weco/storage/store/dynamo/DynamoVersionedHybridStore.scala
@@ -2,7 +2,6 @@ package weco.storage.store.dynamo
 
 import weco.storage.providers.s3.S3ObjectLocation
 import weco.storage.store.VersionedHybridStore
-import weco.storage.providers.s3.S3ObjectLocation
 
 class DynamoVersionedHybridStore[Id, V, T](
   store: DynamoHybridStoreWithMaxima[Id, V, T])(implicit N: Numeric[V])

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryHybridStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryHybridStore.scala
@@ -2,7 +2,6 @@ package weco.storage.store.memory
 
 import weco.storage.store._
 import weco.storage.streaming.Codec
-import weco.storage.streaming.Codec
 
 class MemoryHybridStore[Ident, T](
   implicit val typedStore: MemoryTypedStore[String, T],

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryStreamStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryStreamStore.scala
@@ -17,7 +17,7 @@ class MemoryStreamStore[Ident](val memoryStore: MemoryStore[Ident, Array[Byte]])
       // This is sort of cheating, but since we created these streams the lengths
       // should never be incorrect, and it means we can't get an EncoderError
       // (a WriteError) from inside a REad method.
-      inputStream = bytesCodec.toStream(bytes).right.get
+      inputStream = bytesCodec.toStream(bytes).toOption.get
     } yield Identified(id, inputStream)
 
   override def put(id: Ident)(entry: InputStreamWithLength): WriteEither =

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryTypedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryTypedStore.scala
@@ -3,7 +3,6 @@ package weco.storage.store.memory
 import org.apache.commons.io.IOUtils
 import weco.storage.store._
 import weco.storage.streaming.Codec
-import weco.storage.streaming.Codec
 
 class MemoryTypedStore[Ident, T](initialEntries: Map[Ident, T] =
                                    Map.empty[Ident, T])(
@@ -14,7 +13,7 @@ class MemoryTypedStore[Ident, T](initialEntries: Map[Ident, T] =
   val initial = initialEntries.map {
     case (location, bytes) =>
       location -> IOUtils.toByteArray(
-        codec.toStream(bytes).right.get
+        codec.toStream(bytes).toOption.get
       )
   }
 

--- a/storage/src/main/scala/weco/storage/store/memory/MemoryVersionedStore.scala
+++ b/storage/src/main/scala/weco/storage/store/memory/MemoryVersionedStore.scala
@@ -4,7 +4,6 @@ import weco.storage.Version
 import weco.storage.maxima.Maxima
 import weco.storage.maxima.memory.MemoryMaxima
 import weco.storage.store.VersionedStore
-import weco.storage.maxima.Maxima
 
 class MemoryVersionedStore[Id, T](
   store: MemoryStore[Version[Id, Int], T] with Maxima[Id, Version[Id, Int], T]

--- a/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3MultipartUploader.scala
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.s3.model.{
 }
 import weco.storage.providers.s3.S3ObjectLocation
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 trait S3MultipartUploader extends Logging {

--- a/storage/src/test/scala/weco/storage/dynamo/DynamoFormatTest.scala
+++ b/storage/src/test/scala/weco/storage/dynamo/DynamoFormatTest.scala
@@ -14,9 +14,6 @@ import org.scalatest.matchers.should.Matchers
 import weco.storage.fixtures.DynamoFixtures
 import weco.storage.fixtures.DynamoFixtures.Table
 import DynamoTimeFormat._
-
-import scala.language.higherKinds
-
 trait DynamoFormatTestCases[T]
     extends AnyFunSpec
     with Matchers

--- a/storage/src/test/scala/weco/storage/fixtures/DynamoFixtures.scala
+++ b/storage/src/test/scala/weco/storage/fixtures/DynamoFixtures.scala
@@ -20,7 +20,7 @@ import weco.fixtures._
 import weco.storage.dynamo.DynamoConfig
 
 import java.net.URI
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable
 
 object DynamoFixtures {
@@ -42,7 +42,7 @@ trait DynamoFixtures
       .endpointOverride(new URI("http://localhost:45678"))
       .build()
 
-  implicit val scanamo = Scanamo(dynamoClient)
+  implicit val scanamo: Scanamo = Scanamo(dynamoClient)
 
   def nonExistentTable: Table =
     Table(
@@ -107,9 +107,9 @@ trait DynamoFixtures
 
   def getExistingTableItem[T: DynamoFormat](id: String, table: Table): T = {
     val record = getTableItem[T](id, table)
-    record shouldBe 'defined
-    record.get shouldBe 'right
-    record.get.right.get
+    record shouldBe Symbol("defined")
+    record.get shouldBe Symbol("right")
+    record.get.toOption.get
   }
 
   def scanTable[T: DynamoFormat](

--- a/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
+++ b/storage/src/test/scala/weco/storage/fixtures/S3Fixtures.scala
@@ -22,7 +22,7 @@ import weco.storage.streaming.Codec._
 import weco.storage.streaming.InputStreamWithLength
 
 import java.net.URI
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object S3Fixtures {
@@ -167,7 +167,7 @@ trait S3Fixtures
   }
 
   def getJsonFromS3(location: S3ObjectLocation): Json =
-    parse(getContentFromS3(location)).right.get
+    parse(getContentFromS3(location)).value
 
   def getObjectFromS3[T](location: S3ObjectLocation)(
     implicit decoder: Decoder[T]): T =

--- a/storage/src/test/scala/weco/storage/generators/S3ObjectLocationGenerators.scala
+++ b/storage/src/test/scala/weco/storage/generators/S3ObjectLocationGenerators.scala
@@ -25,7 +25,7 @@ trait S3ObjectLocationGenerators extends RandomGenerators {
         Seq(
           "_" + createBucket,
           randomAlphanumeric().toUpperCase() + createBucket,
-          createBucket + randomAlphanumeric().toUpperCase(),
+          createBucket.toString + randomAlphanumeric().toUpperCase(),
           randomAlphanumeric(length = randomInt(from = 50, to = 100))
         ))
       .head

--- a/storage/src/test/scala/weco/storage/locking/LockingServiceTestCases.scala
+++ b/storage/src/test/scala/weco/storage/locking/LockingServiceTestCases.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.TestWith
 import weco.storage.fixtures.LockingServiceFixtures
 import weco.storage.locking.memory.PermanentLock
-import weco.storage.fixtures.LockingServiceFixtures
 
 import scala.util.{Success, Try}
 

--- a/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockDaoFixtures.scala
+++ b/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockDaoFixtures.scala
@@ -22,7 +22,6 @@ import weco.storage.dynamo.DynamoTimeFormat._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.language.higherKinds
 
 trait DynamoLockDaoFixtures
     extends LockDaoFixtures[String, UUID, Table]

--- a/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockDaoTest.scala
+++ b/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockDaoTest.scala
@@ -18,7 +18,6 @@ import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.locking.{LockDaoTestCases, LockFailure, UnlockFailure}
 
 import scala.concurrent.duration._
-import scala.language.higherKinds
 
 class DynamoLockDaoTest
     extends LockDaoTestCases[String, UUID, Table]

--- a/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockingServiceTest.scala
+++ b/storage/src/test/scala/weco/storage/locking/dynamo/DynamoLockingServiceTest.scala
@@ -3,13 +3,8 @@ package weco.storage.locking.dynamo
 import java.util.UUID
 import org.scalatest.EitherValues
 import org.scanamo.generic.auto._
-import weco.storage.dynamo.DynamoTimeFormat._
 import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.locking.LockingServiceTestCases
-import weco.storage.fixtures.DynamoFixtures.Table
-
-import scala.language.higherKinds
-
 class DynamoLockingServiceTest
     extends LockingServiceTestCases[String, UUID, Table]
     with DynamoLockDaoFixtures

--- a/storage/src/test/scala/weco/storage/maxima/MaximaTestCases.scala
+++ b/storage/src/test/scala/weco/storage/maxima/MaximaTestCases.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.TestWith
 import weco.storage.{Identified, IdentityKey, NoMaximaValueError, Version}
 import weco.storage.generators.{Record, RecordGenerators}
-import weco.storage.generators.{Record, RecordGenerators}
 
 trait MaximaTestCases
     extends AnyFunSpec

--- a/storage/src/test/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
+++ b/storage/src/test/scala/weco/storage/maxima/dynamo/DynamoHashRangeMaximaTest.scala
@@ -17,7 +17,6 @@ import weco.storage.generators.Record
 import weco.storage.maxima.MaximaTestCases
 import weco.storage.{IdentityKey, Version}
 
-import scala.language.higherKinds
 
 class DynamoHashRangeMaximaTest extends MaximaTestCases with DynamoFixtures {
   type Entry = DynamoHashRangeEntry[IdentityKey, Int, Record]

--- a/storage/src/test/scala/weco/storage/providers/s3/S3ObjectLocationTest.scala
+++ b/storage/src/test/scala/weco/storage/providers/s3/S3ObjectLocationTest.scala
@@ -12,9 +12,6 @@ class S3ObjectLocationTest
     with EitherValues
     with S3ObjectLocationGenerators {
 
-  import S3ObjectLocation._
-  import S3ObjectLocationPrefix._
-
   describe("S3ObjectLocation") {
     describe("JSON") {
       it("can serialise and deserialise to JSON") {

--- a/storage/src/test/scala/weco/storage/store/HybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/HybridStoreTestCases.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import weco.fixtures.TestWith
 import weco.storage.generators.StreamGenerators
 import weco.storage.streaming.InputStreamWithLength
-import weco.storage._
 import weco.storage.{
   DanglingHybridStorePointerError,
   DoesNotExistError,
@@ -14,7 +13,6 @@ import weco.storage.{
   ReadError,
   WriteError
 }
-import weco.storage.generators.StreamGenerators
 
 trait HybridStoreTestCases[
   IndexedStoreId,

--- a/storage/src/test/scala/weco/storage/store/StoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/StoreTestCases.scala
@@ -4,7 +4,6 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.EitherValues
 import weco.storage.store.fixtures.StoreFixtures
 import weco.storage.{Identified, NotFoundError, WriteError}
-import weco.storage.WriteError
 
 trait StoreTestCases[Id, T, Namespace, StoreContext]
     extends AnyFunSpec

--- a/storage/src/test/scala/weco/storage/store/TypedStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/TypedStoreTestCases.scala
@@ -14,8 +14,6 @@ import weco.storage.{
   StoreReadError,
   StoreWriteError
 }
-import weco.storage.store.fixtures.TypedStoreFixtures
-import weco.storage.streaming.{Codec, InputStreamWithLength}
 
 trait TypedStoreTestCases[Ident,
                           T,

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeReadableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeReadableTest.scala
@@ -10,8 +10,6 @@ import weco.storage.generators.Record
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
-import scala.language.higherKinds
-
 class DynamoHashRangeReadableTest
     extends DynamoReadableTestCases[
       Version[String, Int],

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeStoreTest.scala
@@ -9,13 +9,6 @@ import weco.storage.fixtures.DynamoFixtures
 import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.generators.{Record, RecordGenerators}
 import weco.storage.store.StoreWithoutOverwritesTestCases
-import weco.storage.dynamo.DynamoHashRangeEntry
-import weco.storage.fixtures.DynamoFixtures
-import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.generators.{Record, RecordGenerators}
-import weco.storage.store.StoreWithoutOverwritesTestCases
-
-import scala.language.higherKinds
 
 class DynamoHashRangeStoreTest
     extends StoreWithoutOverwritesTestCases[

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeWritableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashRangeWritableTest.scala
@@ -14,7 +14,6 @@ import weco.storage.generators.{Record, RecordGenerators}
 import weco.storage.Version
 import weco.storage.fixtures.DynamoFixtures.Table
 
-import scala.language.higherKinds
 
 class DynamoHashRangeWritableTest
     extends DynamoWritableTestCases[

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashReadableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashReadableTest.scala
@@ -13,9 +13,6 @@ import software.amazon.awssdk.services.dynamodb.model.{
   GetItemRequest,
   ScalarAttributeType
 }
-
-import scala.language.higherKinds
-
 class DynamoHashReadableTest
     extends DynamoReadableTestCases[
       String,

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashStoreTest.scala
@@ -10,9 +10,6 @@ import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.generators.{Record, RecordGenerators}
 import weco.storage.maxima.MaximaTestCases
 import weco.storage.store.StoreWithoutOverwritesTestCases
-
-import scala.language.higherKinds
-
 class DynamoHashStoreTest
     extends StoreWithoutOverwritesTestCases[
       Version[IdentityKey, Int],

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashWritableTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHashWritableTest.scala
@@ -14,11 +14,6 @@ import software.amazon.awssdk.services.dynamodb.model.{
 }
 import weco.storage.Version
 import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.dynamo.DynamoHashEntry
-import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.generators.{Record, RecordGenerators}
-
-import scala.language.higherKinds
 
 class DynamoHashWritableTest
     extends DynamoWritableTestCases[

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTest.scala
@@ -8,8 +8,6 @@ import weco.storage.fixtures.S3Fixtures.Bucket
 import weco.storage.generators.Record
 import weco.storage.providers.s3.S3ObjectLocation
 
-import scala.language.higherKinds
-
 class DynamoHybridStoreTest
     extends DynamoHybridStoreTestCases[
       DynamoHashStore[String, Int, S3ObjectLocation]

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -16,15 +16,8 @@ import weco.storage.{
   StoreReadError,
   StoreWriteError
 }
-import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.fixtures.{DynamoFixtures, S3Fixtures}
-import weco.storage.fixtures.S3Fixtures.Bucket
-import weco.storage.generators.{Record, RecordGenerators}
-import weco.storage.providers.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.store.HybridStoreWithoutOverwritesTestCases
-import weco.storage.store.s3.{S3StreamStore, S3TypedStore}
 
-import scala.language.higherKinds
 
 trait DynamoHybridStoreTestCases[
   DynamoStoreImpl <: Store[Version[String, Int], S3ObjectLocation]]

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoMultipleVersionStoreTest.scala
@@ -14,14 +14,8 @@ import weco.storage.dynamo.DynamoHashRangeEntry
 import weco.storage.fixtures.DynamoFixtures
 import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.generators.{Record, RecordGenerators}
-import weco.storage.store._
-import weco.storage.dynamo.DynamoHashRangeEntry
-import weco.storage.fixtures.DynamoFixtures
-import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.generators.{Record, RecordGenerators}
 import weco.storage.store.VersionedStoreWithoutOverwriteTestCases
 
-import scala.language.higherKinds
 
 class DynamoMultipleVersionStoreTest
     extends VersionedStoreWithoutOverwriteTestCases[String, Record, Table]

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoReadableTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoReadableTestCases.scala
@@ -14,9 +14,6 @@ import software.amazon.awssdk.services.dynamodb.model.{
   DynamoDbException,
   ResourceNotFoundException
 }
-
-import scala.language.higherKinds
-
 trait DynamoReadableTestCases[
   DynamoIdent, EntryType <: DynamoEntry[String, Record]]
     extends AnyFunSpec

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoSingleVersionStoreTest.scala
@@ -9,10 +9,6 @@ import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.generators.{Record, RecordGenerators}
 import weco.storage.store._
 import weco.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
-import weco.storage.fixtures.DynamoFixtures
-import weco.storage.fixtures.DynamoFixtures.Table
-
-import scala.language.higherKinds
 
 class DynamoSingleVersionStoreTest
     extends VersionedStoreWithOverwriteTestCases[String, Record, Table]

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
@@ -10,9 +10,6 @@ import weco.storage.providers.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.store.s3.S3TypedStore
 import weco.storage.store.VersionedStoreWithOverwriteTestCases
 import weco.storage.{MaximaReadError, StoreReadError, StoreWriteError, Version}
-
-import scala.language.higherKinds
-
 class DynamoVersionedHybridStoreTest
     extends VersionedStoreWithOverwriteTestCases[
       String,

--- a/storage/src/test/scala/weco/storage/store/memory/MemoryStreamStoreFixtures.scala
+++ b/storage/src/test/scala/weco/storage/store/memory/MemoryStreamStoreFixtures.scala
@@ -4,8 +4,6 @@ import weco.fixtures.TestWith
 import weco.storage.store.fixtures.StreamStoreFixtures
 import weco.storage.streaming.Codec.bytesCodec
 import weco.storage.streaming.InputStreamWithLength
-import weco.storage.store.fixtures.StreamStoreFixtures
-import weco.storage.streaming.InputStreamWithLength
 
 trait MemoryStreamStoreFixtures[Ident]
     extends StreamStoreFixtures[

--- a/storage_typesafe/src/main/scala/weco/storage/typesafe/LockingBuilder.scala
+++ b/storage_typesafe/src/main/scala/weco/storage/typesafe/LockingBuilder.scala
@@ -2,10 +2,8 @@ package weco.storage.typesafe
 
 import com.typesafe.config.Config
 import weco.storage.locking.dynamo.{DynamoLockDao, DynamoLockingService}
-import weco.storage.locking.dynamo.DynamoLockDao
 
 import scala.concurrent.ExecutionContext
-import scala.language.higherKinds
 
 object LockingBuilder {
   def buildDynamoLockingService[Out, OutMonad[_]](config: Config,

--- a/typesafe_app/src/main/scala/weco/Tracing.scala
+++ b/typesafe_app/src/main/scala/weco/Tracing.scala
@@ -9,7 +9,7 @@ import co.elastic.apm.attach.ElasticApmAttacher
 import com.typesafe.config.Config
 import weco.typesafe.config.builders.EnrichConfig._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.ref.WeakReference
@@ -74,7 +74,7 @@ object Tracing {
     threadLocalTransactionReference.value.get
       .getOrElse(ElasticApm.currentTransaction())
 
-  def currentTransaction_=(t: Transaction) {
+  def currentTransaction_=(t: Transaction) = {
     threadLocalTransactionReference.value = new WeakReference[Transaction](t)
   }
 }

--- a/typesafe_app/src/main/scala/weco/typesafe/config/builders/EnrichConfig.scala
+++ b/typesafe_app/src/main/scala/weco/typesafe/config/builders/EnrichConfig.scala
@@ -10,7 +10,7 @@ object EnrichConfig {
     private def cleanUpPath(p: String): String =
       // Sometimes we may get a path that features two double dots, if there's an
       // empty namespace -- in this case, elide the two dots into one.
-      p.replaceAllLiterally("..", ".")
+      p.replace("..", ".")
 
     private def getPathValue[T](path: String)(f: String => T): Option[T] = {
       val cleanPath = cleanUpPath(path)


### PR DESCRIPTION
## What does this change?

Bump Alpakka version to 4.0.0. This is the first step towards migrating from Akka to Pekko — Pekko Connectors is a replacement for Alpakka but it's based on version 4.0.0, so we need to upgrade first. See https://pekko.apache.org/docs/pekko-connectors/1.0/release-notes/index.html.

Updating Alpakka to version 4.0.0 requires:
* Updating Scala from 2.12 to 2.13 (Alpakka 4.0.0 [only supports Scala 2.13](https://mvnrepository.com/artifact/com.lightbend.akka/akka-stream-alpakka-google-cloud-pub-sub-grpc))
* Updating the Scanamo package to successfully resolve dependencies

## How to test


## How can we measure success?

Alpakka is successfully updated to version 4.0.0 and no bugs are introduced in the process. 

## Have we considered potential risks?


