### PR TITLE
Give release action permissions to push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,21 @@ jobs:
           git fetch --tags
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           python3 .github/scripts/create_release.py ${LATEST_TAG} $(pwd)
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 129326 # App ID of the Wellcome Collection app
+          private-key: ${{ secrets.WELLCOME_COLLECTION_APP_PRIVATE_KEY }}
+
       - name: Configure git
         # We need to give the GitHub action full repo privileges via a PAT so that it can push the release directly into main
         run: |
           git config --global user.name "GitHub on behalf of Wellcome Collection"
           git config --global user.email "wellcomedigitalplatform@wellcome.ac.uk"
           
-          git remote set-url origin https://x-access-token:${{ secrets.FULL_REPO_PRIVILEGES_PAT }}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,24 +38,32 @@ jobs:
     if: needs.check-for-release-file.outputs.has-release == 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Update CHANGELOG.md and build.sbt
         run: |
           git fetch --tags
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           python3 .github/scripts/create_release.py ${LATEST_TAG} $(pwd)
-      - name: Commit and push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.FULL_REPO_PRIVILEGES_PAT }}
+      - name: Configure git
         run: |
-          NEW_TAG=$(cat CHANGELOG.md | grep -m1 -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
           git config --global user.name "GitHub on behalf of Wellcome Collection"
           git config --global user.email "wellcomedigitalplatform@wellcome.ac.uk"
+          
+          git remote set-url origin https://x-access-token:${{ secrets.FULL_REPO_PRIVILEGES_PAT }}@github.com/${{ github.repository }}.git
+
+      - name: Commit and push changes
+        run: |
           git checkout main
           git pull
+          
           git add CHANGELOG.md build.sbt
           git rm RELEASE.md
+          
+          NEW_TAG=$(cat CHANGELOG.md | grep -m1 -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
           git commit -m "$(printf "Release: Bump version to ${NEW_TAG}\n\n[skip ci]")"
           git tag ${NEW_TAG}
+
           git push origin main
           git push origin --tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: "Create release and publish packages to Sonatype"
 
-on:
-  push:
-    branches:
-      - main
+on: push
+
+#on:
+#  push:
+#    branches:
+#      - main
 
 permissions:
   id-token: write
@@ -125,4 +127,4 @@ jobs:
       - name: Publish to Sonatype
         run: |
           PGP_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }} sbt "project ${{ matrix.service }}" publishSigned
-          sbt "project ${{ matrix.service }}" sonatypeBundleRelease
+#          sbt "project ${{ matrix.service }}" sonatypeBundleRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           python3 .github/scripts/create_release.py ${LATEST_TAG} $(pwd)
       - name: Configure git
+        # We need to give the GitHub action full repo privileges via a PAT so that it can push the release directly into main
         run: |
           git config --global user.name "GitHub on behalf of Wellcome Collection"
           git config --global user.email "wellcomedigitalplatform@wellcome.ac.uk"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           python3 .github/scripts/create_release.py ${LATEST_TAG} $(pwd)
       - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.FULL_REPO_PRIVILEGES_PAT }}
         run: |
           NEW_TAG=$(cat CHANGELOG.md | grep -m1 -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
           git config --global user.name "GitHub on behalf of Wellcome Collection"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: "Create release and publish packages to Sonatype"
 
-on: push
-
-#on:
-#  push:
-#    branches:
-#      - main
+on:
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -127,4 +125,4 @@ jobs:
       - name: Publish to Sonatype
         run: |
           PGP_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }} sbt "project ${{ matrix.service }}" publishSigned
-#          sbt "project ${{ matrix.service }}" sonatypeBundleRelease
+          sbt "project ${{ matrix.service }}" sonatypeBundleRelease


### PR DESCRIPTION
## What does this change?

Gives the `release` GitHub action the necessary permissions to push changes directly into main. 

This is done by configuring the `release` action to assume the role of the Wellcome Collection GitHub app when pushing changes to main. The implementation involves creating a token from the app's private key and follows [official GitHub documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow).

Separately, the Wellcome Collection GitHub app was given the necessary permissions to bypass the [requires-review](https://github.com/organizations/wellcomecollection/settings/rules/638886) rule.

## How to test

I tested this change by temporarily removing the part of the workflow which publishes to Sonatype and running the GitHub action from this branch, which resulted in a successful push to main (see [here](https://github.com/wellcomecollection/scala-libs/commit/3ae383e8ea7050b126c345a6edf93130b4097807)), which I subsequently reverted. 

## How can we measure success?

The `release` action runs successfully. 

## Have we considered potential risks?

Giving the GitHub action full repo access comes with security risks. However, the original Buildkite pipeline was using a similar setup, so this should not introduce any new risks.

I have considered alternative release setups which do not involve pushing directly into main, but these setups have significant limitations (see [here](https://wellcome.slack.com/archives/C02ANCYL90E/p1726759356031529)) and are not viable alternatives. 
