### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           - elasticsearch
           - elasticsearch_typesafe
           - sierra
+          - sierra_typesafe
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/report-evictions.yml
+++ b/.github/workflows/report-evictions.yml
@@ -28,6 +28,7 @@ jobs:
           - elasticsearch
           - elasticsearch_typesafe
           - sierra
+          - sierra_typesafe
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,7 @@ jobs:
           - elasticsearch
           - elasticsearch_typesafe
           - sierra
+          - sierra_typesafe
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Update dependencies.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -7,7 +7,7 @@ import xerial.sbt.Sonatype.autoImport.{sonatypeCredentialHost, sonatypePublishTo
 
 object Common {
   def createSettings(projectVersion: String): Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.12.19",
     organization := "org.wellcomecollection",
     homepage := Some(url("https://github.com/wellcomecollection/scala-libs")),
     scmInfo := Some(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val elasticApm = "1.51.0"
     val elastic4s = "8.9.5"
 
-    val aws = "2.25.37"
+    val aws = "2.25.70"
 
     // Note: this should probably match the version of Circe used by elastic4s.
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala
@@ -24,9 +24,9 @@ object Dependencies {
     // Provides slf4j-api
     val grizzled = "1.3.4"
 
-    val pekko = "1.1.0"
+    val pekko = "1.1.1"
     val pekkoConnectors = "1.0.2"
-    val pekkoHttp = "1.0.1"
+    val pekkoHttp = "1.1.0"
     val pekkoHttpJson = "2.6.0"
 
     // This needs to be set explicitly to match the language version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val elasticApm = "1.22.0"
     val elastic4s = "8.9.1"
 
-    val aws = "2.25.28"
+    val aws = "2.25.37"
 
     // Note: this should probably match the version of Circe used by elastic4s.
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,29 +2,29 @@ import sbt._
 
 object Dependencies {
   lazy val versions = new {
-    val elasticApm = "1.22.0"
-    val elastic4s = "8.9.1"
+    val elasticApm = "1.51.0"
+    val elastic4s = "8.9.5"
 
     val aws = "2.25.37"
 
     // Note: this should probably match the version of Circe used by elastic4s.
     // See https://github.com/sksamuel/elastic4s/blob/master/project/Dependencies.scala
-    val circe = "0.14.5"
-    val circeGenericExtras = "0.14.3"
+    val circe = "0.14.9"
+    val circeGenericExtras = "0.14.4"
 
-    val typesafe = "1.4.2"
-    val logback = "1.4.7"
-    val mockito = "1.10.19"
-    val scalatest = "3.2.3"
+    val typesafe = "1.4.3"
+    val logback = "1.4.14"
+    val mockito = "5.13.0"
+    val scalatest = "3.2.19"
     val scalatestPlus = "3.1.2.0"
     val scalatestPlusMockitoArtifactId = "mockito-3-2"
-    val scanamo = "1.0.4"
-    val apacheCommons = "2.6"
+    val scanamo = "1.1.1"
+    val apacheCommons = "2.16.1"
 
     // Provides slf4j-api
     val grizzled = "1.3.4"
 
-    val pekko = "1.0.3"
+    val pekko = "1.1.0"
     val pekkoConnectors = "1.0.2"
     val pekkoHttp = "1.0.1"
     val pekkoHttpJson = "2.6.0"
@@ -36,7 +36,7 @@ object Dependencies {
     //
     //    java.lang.NoClassDefFoundError: scala/reflect/internal/Names$Name
     //
-    val scalaReflectVersion = "2.12.15"
+    val scalaReflectVersion = "2.12.19"
   }
 
   val circeDependencies = Seq(
@@ -121,7 +121,7 @@ object Dependencies {
   // See https://github.com/elastic/apm-agent-java/issues/2353 for an explanation
   // of the issue this addresses.
   val jnaDependencies: Seq[ModuleID] = Seq(
-    "net.java.dev.jna" % "jna" % "5.7.0"
+    "net.java.dev.jna" % "jna" % "5.14.0"
   )
 
   val localstackDependencies = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
-addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.22.0")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.6.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.2")
 addDependencyTreePlugin

--- a/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/weco/storage/store/HybridStoreWithMaxima.scala
@@ -14,10 +14,8 @@ trait HybridStoreWithMaxima[Id, V, TypedStoreId, T]
     extends HybridStore[Version[Id, V], TypedStoreId, T]
     with Maxima[Id, Version[Id, V], T] {
 
-  override implicit val indexedStore: Store[Version[Id, V], TypedStoreId] with Maxima[
-    Id,
-    Version[Id, V],
-    TypedStoreId]
+  override implicit val indexedStore: Store[Version[Id, V], TypedStoreId]
+    with Maxima[Id, Version[Id, V], TypedStoreId]
 
   override def max(id: Id): MaxEither =
     indexedStore


### PR DESCRIPTION
## What does this change?

* Update dependencies to resolve a few security alerts. This includes the changes from  https://github.com/wellcomecollection/scala-libs/pull/242 and https://github.com/wellcomecollection/scala-libs/pull/241 so that a new version of scala-libs can be released with the updated dependencies. 
* Add the `sierra_typesafe` project into all actions (test, report evictions, and release). In the original version this project was left out by accident (project names were copied from the "Test" group of the original Buildkite pipeline, which also omitted this project).


This change should fix all logback-related security alerts across all repos using `scala-libs`.
