### PR TITLE
S3StreamWritable bug fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     strategy:
+      fail-fast: false
       matrix:
         service:
           - fixtures
           - http
+          - http_typesafe
           - json
           - typesafe_app
           - monitoring

--- a/.github/workflows/report-evictions.yml
+++ b/.github/workflows/report-evictions.yml
@@ -17,6 +17,7 @@ jobs:
         service:
           - fixtures
           - http
+          - http_typesafe
           - json
           - typesafe_app
           - monitoring

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
         service:
           - fixtures
           - http
+          - http_typesafe
           - json
           - typesafe_app
           - monitoring

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+S3StreamWritable bug fix (replace `read` by `readNBytes`). 

--- a/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
+++ b/storage/src/main/scala/weco/storage/store/s3/S3StreamWritable.scala
@@ -41,7 +41,7 @@ trait S3StreamWritable
             if (inputStream.length > 0) {
               val bytes: Array[Byte] = new Array[Byte](inputStream.length.toInt)
               val bytesRead =
-                inputStream.read(bytes, 0, inputStream.length.toInt)
+                inputStream.readNBytes(bytes, 0, inputStream.length.toInt)
 
               if (bytesRead < inputStream.length) {
                 throw new RuntimeException(
@@ -93,7 +93,7 @@ trait S3StreamWritable
       val partLength = (end - start).toInt
 
       val bytes: Array[Byte] = new Array[Byte](partLength)
-      val bytesRead = inputStream.read(bytes, 0, partLength)
+      val bytesRead = inputStream.readNBytes(bytes, 0, partLength)
 
       if (bytesRead < partLength) {
         throw new RuntimeException(


### PR DESCRIPTION
## What does this change?

* Replaces the `read` method by the `readNBytes` method when reading the contents of an InputStream to ensure that all requested bytes are always read. See [here](https://wellcome.slack.com/archives/C02ANCYL90E/p1728290049040269?thread_ts=1728289950.021739&cid=C02ANCYL90E) for more context.
* Adds a missing project to the release action and disables `fast-fail` on the action to make sure that a specific project failing during the release process doesn't affect all other pending releases

