### PR TITLE
stop using our own ECR to pull zenko/cloudserver

### DIFF
--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "45678:8000"
   s3:
-    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+    image: "zenko/cloudserver:8.1.8"
     environment:
       - "S3BACKEND=mem"
     ports:


### PR DESCRIPTION
## What does this change?

This fixes the problem where builds are failing because the storage tests cannot download Zenko/cloudserver.

Previously, we were storing it in our own private ECR, which requires docker to login, and the test step was not doing that login.

There were two options as to how this could have been fixed, one would have been to login using the [docker login action](https://github.com/docker/login-action), but I went with the simpler approach, as I don't think there is any value in using our own ECR for these tests (I believe the original rationale was that we run our tests so frequently that the public docker hub would complain.  These tests are not run very frequently)

## How to test

Look at the checks for this PR.  [Run tests / run-tests (storage) (pull_request)](https://github.com/wellcomecollection/scala-libs/actions/runs/12634409748/job/35202087278?pr=259) is successful.

## How can we measure success?

We can now merge other PRs, confident that they haven't broken the storage lib.

## Have we considered potential risks?

Perhaps I'm wrong about the need to pull this from our own registry.  If that's the cases, then we can reinstate it and make docker login instead, as mentioned above.
