### PR TITLE
Use localstack in storage tests

### DIFF
--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -5,19 +5,9 @@ services:
     ports:
       - "45678:8000"
   s3:
-    image: "zenko/cloudserver:8.1.8"
+    image: "public.ecr.aws/localstack/localstack:4.0.0"
     environment:
-      - "S3BACKEND=mem"
+      - SERVICES=s3
+      - ALLOW_NONSTANDARD_REGIONS=1
     ports:
-      - "33333:8000"
-
-    # We've seen flakiness when this container doesn't start fast enough,
-    # and the first few tests to interact with S3 fail.  This uses
-    # docker-compose healthchecks to check the container is returning
-    # a 401 Unauthorized before continuing.
-    # See https://docs.docker.com/compose/compose-file/#/healthcheck
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:33333"]
-      interval: 2s
-      timeout: 10s
-      retries: 5
+      - "33333:4566"

--- a/storage/src/main/scala/weco/storage/providers/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/providers/s3/S3Errors.scala
@@ -28,6 +28,10 @@ object S3Errors {
         if exc.getMessage.startsWith("The specified bucket is not valid") =>
       StoreReadError(exc)
 
+    case exc: S3Exception
+      if exc.getMessage.startsWith("The specified bucket does not exist") =>
+      StoreReadError(exc)
+
     case exc: SdkClientException
         if exc.getMessage.startsWith("Unable to execute HTTP request") =>
       new StoreReadError(exc) with RetryableError
@@ -53,6 +57,9 @@ object S3Errors {
     // e.g. S3Exception: Object key is too long. Maximum number of bytes allowed in keys is 915.
     case exc: S3Exception
         if exc.getMessage.startsWith("Object key is too long") =>
+      InvalidIdentifierFailure(exc)
+    case exc: S3Exception
+      if exc.getMessage.startsWith("Your key is too long") =>
       InvalidIdentifierFailure(exc)
 
     case exc => StoreWriteError(exc)

--- a/storage/src/main/scala/weco/storage/providers/s3/S3Errors.scala
+++ b/storage/src/main/scala/weco/storage/providers/s3/S3Errors.scala
@@ -29,7 +29,7 @@ object S3Errors {
       StoreReadError(exc)
 
     case exc: S3Exception
-      if exc.getMessage.startsWith("The specified bucket does not exist") =>
+        if exc.getMessage.startsWith("The specified bucket does not exist") =>
       StoreReadError(exc)
 
     case exc: SdkClientException
@@ -59,7 +59,7 @@ object S3Errors {
         if exc.getMessage.startsWith("Object key is too long") =>
       InvalidIdentifierFailure(exc)
     case exc: S3Exception
-      if exc.getMessage.startsWith("Your key is too long") =>
+        if exc.getMessage.startsWith("Your key is too long") =>
       InvalidIdentifierFailure(exc)
 
     case exc => StoreWriteError(exc)

--- a/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/weco/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -171,7 +171,7 @@ trait DynamoHybridStoreTestCases[
 
                     value shouldBe a[StoreWriteError]
                     value.e.getMessage should startWith(
-                      "The specified bucket is not valid")
+                      "The specified bucket does not exist")
                   }
                 }
               }
@@ -206,7 +206,7 @@ trait DynamoHybridStoreTestCases[
                 val value = result.left.value
 
                 value shouldBe a[InvalidIdentifierFailure]
-                value.e.getMessage should startWith("Object key is too long")
+                value.e.getMessage should include("key is too long")
               }
             }
           }

--- a/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3StreamStoreTest.scala
@@ -59,10 +59,11 @@ class S3StreamStoreTest
         withStoreImpl(initialEntries = Map.empty) { store =>
           val invalidLocation = createS3ObjectLocationWith(createInvalidBucket)
           val err = store.get(invalidLocation).left.value
-          err shouldBe a[StoreReadError]
+          err shouldBe a[DoesNotExistError]
 
           err.e shouldBe a[S3Exception]
-          err.e.getMessage should startWith("The specified bucket is not valid")
+          err.e.getMessage should startWith(
+            "The specified bucket does not exist")
         }
       }
     }
@@ -102,7 +103,7 @@ class S3StreamStoreTest
 
           val err = result.e
           err shouldBe a[S3Exception]
-          err.getMessage should startWith("The specified bucket is not valid")
+          err.getMessage should startWith("The specified bucket does not exist")
         }
       }
 
@@ -121,7 +122,7 @@ class S3StreamStoreTest
             val value = store.put(id)(entry).left.value
 
             value shouldBe a[InvalidIdentifierFailure]
-            value.e.getMessage should startWith("Object key is too long")
+            value.e.getMessage should include("key is too long")
           }
         }
       }

--- a/storage/src/test/scala/weco/storage/store/s3/S3TypedStoreTest.scala
+++ b/storage/src/test/scala/weco/storage/store/s3/S3TypedStoreTest.scala
@@ -61,7 +61,7 @@ class S3TypedStoreTest
   describe("S3TypedStore") {
     it("errors if the object key is too long") {
       withLocalS3Bucket { bucket =>
-        // Maximum length of an s3 key is 1024 bytes as of 25/06/2019
+        // Maximum length of a s3 key is 1024 bytes as of 25/06/2019
         // https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
         val location = S3ObjectLocation(
           bucket = bucket.name,
@@ -74,7 +74,7 @@ class S3TypedStoreTest
           val value = store.put(location)(entry).left.value
 
           value shouldBe a[InvalidIdentifierFailure]
-          value.e.getMessage should startWith("Object key is too long")
+          value.e.getMessage should include("key is too long")
         }
       }
     }


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/scala-libs/pull/259

Instead of using the Zenko version of S3, this switches to using the Localstack version. 

We may wish to use Localstack to avoid future maintenance issues with the Zenko images that don't seem to have been updated in the last 2 years, and so that we can use the ECR public versions of the Localstack images to avoid potential throttling on docker hub (which has been an issue in the past.

> [!Note]
> This change required updated the tests as some of the error messages emitted by the Localstack S3 container image around bucket naming are different from the Zenko image. I have not determined which is "correct" as per comparison to S3 but allowed both.

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Tests can pass, we can release things.

## Have we considered potential risks?

The differing errors may mean that Localstack is incorrect when compared to S3, we've kept both old and new error messages as valid to mitigate.
