### PR TITLE
Fix `in` deprecation - replace with slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # scala-libs
 
-[![Build status](https://badge.buildkite.com/4a84a28feca6865e192e0adaba1c2e33f1e773e58957459c47.svg?branch=main)](https://buildkite.com/wellcomecollection/scala-libraries)
-
 This is a collection of utilities that are shared across our Scala-based repositories ([catalogue-api], [catalogue-pipeline], [storage-service]).
 
 It includes:

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -46,7 +46,7 @@ object Common {
     Test / publishArtifact := true,
     // Don't build scaladocs
     // https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
-    mappings in (Compile, packageDoc) := Nil,
+    Compile /  packageDoc / mappings := Nil,
     version := projectVersion
   )
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,14 +36,14 @@ object Common {
       "-feature",
       "-language:postfixOps"
     ),
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
     publishMavenStyle := true,
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype.credentials"),
     sonatypeCredentialHost := "central.sonatype.com",
     sonatypeRepository := "https://central.sonatype.com/service/local",
     licenses := Seq("MIT" -> url("https://github.com/wellcomecollection/scala-libs/blob/main/LICENSE")),
     publishTo := sonatypePublishToBundle.value,
-    publishArtifact in Test := true,
+    Test / publishArtifact := true,
     // Don't build scaladocs
     // https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
     mappings in (Compile, packageDoc) := Nil,


### PR DESCRIPTION
## What does this change?

When building, there were some messages about the deprecation of 'method in in trait ScopingSetting'

 This PR makes them go away.

See  https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash

## How to test

Look at the run eviction report build step.  It did look like [this](https://github.com/wellcomecollection/scala-libs/actions/runs/12634599045/job/35202686195?pr=259#step:5:54), 
```
Status: Downloaded newer image for 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper:latest
[warn] /home/runner/work/scala-libs/scala-libs/project/Common.scala:39:23: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     parallelExecution in Test := false,
[warn]                       ^
[warn] /home/runner/work/scala-libs/scala-libs/project/Common.scala:46:21: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     publishArtifact in Test := true,
[warn]                     ^
[warn] /home/runner/work/scala-libs/scala-libs/project/Common.scala:49:14: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     mappings in (Compile, packageDoc) := Nil,
[warn]              ^
[warn] 38 feature warnings; re-run with -feature for details
```
it now looks like [this](https://github.com/wellcomecollection/scala-libs/actions/runs/12635308284/job/35204936303?pr=261#step:5:55)
```
Status: Downloaded newer image for 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper:latest
[warn] 38 feature warnings; re-run with -feature for details
```
## How can we measure success?
 Fewer build warnings.  Specifically, none about this matter.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

