### PR TITLE
Scala 2 12 20

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -7,7 +7,7 @@ import xerial.sbt.Sonatype.autoImport.{sonatypeCredentialHost, sonatypePublishTo
 
 object Common {
   def createSettings(projectVersion: String): Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.19",
+    scalaVersion := "2.12.20",
     organization := "org.wellcomecollection",
     homepage := Some(url("https://github.com/wellcomecollection/scala-libs")),
     scmInfo := Some(


### PR DESCRIPTION
## What does this change?
This updates scala to get rid of the three big eviction notices that look a bit like this:
> org.scala-lang:scala-library:2.12.20 is selected over {2.12.19, 2.12.19, 2.12.19, 2.12.15, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.8, 2.12.18, 2.12.19, 2.12.15, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19, 2.12.19}

2.13 exists above this, but that is currently causing problems and I am trying to isolate that by getting everything else as up to date as possible.

## How to test

Look at the comment from GitHub actions on this PR.  It doesn't contain the big scary eviction notes mentioned above (org.slf4j is still subject to eviction, but that is currently outside of our control.
)
## How can we measure success?

It quietens the above warnings.  This makes it easier to spot things that are genuinely concerning.

## Have we considered potential risks?

Maybe this is wrong, but as 2.12.20 is already implicitly being used due to the eviction, so the real-world behaviour should be unchanged.
