### PR TITLE
Setup sbt in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,13 @@ jobs:
           mkdir ~/.sbt
           echo "${{ secrets.SONATYPE_CREDENTIALS }}" > ~/.sbt/sonatype.credentials
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1.1.0
       - name: Publish to Sonatype
         run: |
           ARTIFACT_NAME="${{ matrix.service }}_2.12"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This is a change to the build process to fix a bug in the way that the `sbt` build is run.


### PR DESCRIPTION
## What does this change?

This change adds a GitHub action step to ensure sbt is setup as part of the release action, as this is currently failing: https://github.com/wellcomecollection/scala-libs/actions/runs/12636383833/job/35209020492#step:6:27

I believe there has been a change to what is available on runners (sbt was previously available by default on GHA runners, it now is not and needs explicitly adding). See: https://github.com/actions/setup-java/issues/266

In the future we could consider having our own action for this in the style of https://github.com/guardian/setup-scala (credit to the great @rtyley).

## How to test

- [ ] Merge and release, is it successful?

## How can we measure success?

We can release our shared libs!

## Have we considered potential risks?

This shouldn't break anything further!
